### PR TITLE
formatting updates to python scripts for flake8 

### DIFF
--- a/caldp/__init__.py
+++ b/caldp/__init__.py
@@ -5,7 +5,8 @@ __version__ = None  # Placeholder to trick flake8
 # Packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
-from ._astropy_init import *   # noqa
+from ._astropy_init import *  # noqa
+
 # ----------------------------------------------------------------------------
 
 __all__ = []

--- a/caldp/_astropy_init.py
+++ b/caldp/_astropy_init.py
@@ -1,18 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__']
+__all__ = ["__version__"]
 
 # this indicates whether or not we are in the package's setup.py
 try:
     _ASTROPY_SETUP_
 except NameError:
     import builtins
+
     builtins._ASTROPY_SETUP_ = False
 
 try:
     from .version import version as __version__
 except ImportError:
-    __version__ = ''
+    __version__ = ""
 
 
 if not _ASTROPY_SETUP_:  # noqa
@@ -21,31 +22,33 @@ if not _ASTROPY_SETUP_:  # noqa
     from astropy.config.configuration import (
         update_default_config,
         ConfigurationDefaultMissingError,
-        ConfigurationDefaultMissingWarning)
+        ConfigurationDefaultMissingWarning,
+    )
 
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
+
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
     test.__test__ = False
-    __all__ += ['test']
+    __all__ += ["test"]
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
 
-    if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
+    if not os.environ.get("ASTROPY_SKIP_CONFIG_UPDATE", False):
         config_dir = os.path.dirname(__file__)
         config_template = os.path.join(config_dir, __package__ + ".cfg")
         if os.path.isfile(config_template):
             try:
-                update_default_config(
-                    __package__, config_dir, version=__version__)
+                update_default_config(__package__, config_dir, version=__version__)
             except TypeError as orig_error:
                 try:
                     update_default_config(__package__, config_dir)
                 except ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] +
-                            " Cannot install default profile. If you are "
-                            "importing from source, this is expected.")
+                    wmsg = (
+                        e.args[0] + " Cannot install default profile. If you are "
+                        "importing from source, this is expected."
+                    )
                     warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
                 except Exception:

--- a/caldp/conftest.py
+++ b/caldp/conftest.py
@@ -8,13 +8,15 @@ import os
 from astropy.version import version as astropy_version
 
 # For Astropy 3.0 and later, we can use the standalone pytest plugin
-if astropy_version < '3.0':
+if astropy_version < "3.0":
     from astropy.tests.pytest_plugins import *  # noqa
+
     del pytest_report_header
     ASTROPY_HEADER = True
 else:
     try:
         from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
         ASTROPY_HEADER = True
     except ImportError:
         ASTROPY_HEADER = False
@@ -28,12 +30,14 @@ def pytest_configure(config):
 
         # Customize the following lines to add/remove entries from the list of
         # packages for which version numbers are displayed when running the tests.
-        PYTEST_HEADER_MODULES.pop('Pandas', None)
-        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+        PYTEST_HEADER_MODULES.pop("Pandas", None)
+        PYTEST_HEADER_MODULES["scikit-image"] = "skimage"
 
         from . import __version__
+
         packagename = os.path.basename(os.path.dirname(__file__))
         TESTED_VERSIONS[packagename] = __version__
+
 
 # Uncomment the last two lines in this block to treat all DeprecationWarnings as
 # exceptions. For Astropy v2.0 or later, there are 2 additional keywords,

--- a/caldp/create_previews.py
+++ b/caldp/create_previews.py
@@ -18,13 +18,11 @@ LOGGER = logging.getLogger(__name__)
 
 AUTOSCALE = 99.5
 
-OUTPUT_FORMATS = [
-    ("_thumb", 128),
-    ("", -1)
-]
+OUTPUT_FORMATS = [("_thumb", 128), ("", -1)]
 
 
 # -----------------------------------------------------------------------------------------------------------------
+
 
 def generate_image_preview(input_path, output_path, size):
     cmd = [
@@ -35,15 +33,14 @@ def generate_image_preview(input_path, output_path, size):
         "--asinh-scale",
         f"--output-size={size}",
         "--badpix",
-        input_path
+        input_path,
     ]
 
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()
 
     if process.returncode > 0:
-        LOGGER.error("fitscut failed for %s with status %s: %s",
-                     input_path, process.returncode, stderr)
+        LOGGER.error("fitscut failed for %s with status %s: %s", input_path, process.returncode, stderr)
         raise RuntimeError()
 
     with open(output_path, "wb") as f:
@@ -66,13 +63,7 @@ def generate_image_previews(input_path, output_dir, filename_base):
 def generate_spectral_previews(input_path, output_dir, filename_base):
     before_files = [f for f in os.listdir(output_dir) if os.path.isfile(f)]
 
-    cmd = [
-        "make_hst_spec_previews",
-        "-v",
-        "-t png fits",
-        f"-o {output_dir}",
-        input_path
-    ]
+    cmd = ["make_hst_spec_previews", "-v", "-t png fits", f"-o {output_dir}", input_path]
 
     # output = subprocess.check_output(cmd)
     err = os.system(" ".join(cmd))
@@ -113,13 +104,21 @@ def split_uri(uri):
 
 def list_fits_uris(uri_prefix):
     bucket_name, key = split_uri(uri_prefix)
-    result = subprocess.check_output([
-        "aws", "s3api", "list-objects",
-        "--bucket", bucket_name,
-        "--prefix", key,
-        "--output", "json",
-        "--query", "Contents[].Key"
-    ])
+    result = subprocess.check_output(
+        [
+            "aws",
+            "s3api",
+            "list-objects",
+            "--bucket",
+            bucket_name,
+            "--prefix",
+            key,
+            "--output",
+            "json",
+            "--query",
+            "Contents[].Key",
+        ]
+    )
     return [f"s3://{bucket_name}/{k}" for k in json.loads(result) if k.lower().endswith(".fits")]
 
 
@@ -136,9 +135,7 @@ def main(args, outdir=None):
             log.info("Fetching", input_uri)
             filename = os.path.basename(input_uri)
             input_path = os.path.join(outdir, filename)
-            subprocess.check_call([
-                "aws", "s3", "cp", input_uri, input_path
-            ])
+            subprocess.check_call(["aws", "s3", "cp", input_uri, input_path])
     else:
         input_uris = glob.glob(args.input_uri_prefix.split(":")[-1] + "/*.fits")
         log.info("Processing", len(input_uris), "FITS files from prefix", args.input_uri_prefix)
@@ -152,25 +149,19 @@ def main(args, outdir=None):
             output_uri = os.path.join(args.output_uri_prefix, os.path.basename(output_path))
             if output_uri.startswith("s3://"):  # is set to "none" for local use
                 log.info("Uploading", output_path, "to", output_uri)
-                subprocess.check_call([
-                    "aws", "s3", "cp", "--quiet", output_path, output_uri
-                ])
+                subprocess.check_call(["aws", "s3", "cp", "--quiet", output_path, output_uri])
             else:
                 log.info(f"Copying {output_path} to {output_uri}")
                 os.makedirs(os.path.dirname(output_uri), exist_ok=True)
                 shutil.copy(output_path, output_uri)
-            
-
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Create image and spectral previews")
     parser.add_argument(
-        "input_uri_prefix",
-        help="S3 URI prefix or local directory containing FITS images that require previews")
-    parser.add_argument(
-        "output_uri_prefix",
-        help="S3 URI prefix for writing previews")
+        "input_uri_prefix", help="S3 URI prefix or local directory containing FITS images that require previews"
+    )
+    parser.add_argument("output_uri_prefix", help="S3 URI prefix for writing previews")
     return parser.parse_args()
 
 

--- a/caldp/log.py
+++ b/caldp/log.py
@@ -69,7 +69,7 @@ class CaldpLogger:
         self.name = name
 
         self.handlers = []  # logging handlers, used e.g. to add console or file output streams
-        self.filters = []   # simple CALDP filters, used e.g. to mutate message text
+        self.filters = []  # simple CALDP filters, used e.g. to mutate message text
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(level)
@@ -92,15 +92,17 @@ class CaldpLogger:
             verbose_level = os.environ.get("CALDP_VERBOSITY", 0)
             self.verbose_level = int(verbose_level)
         except Exception:
-            warning("Bad format for CALDP_VERBOSITY =", repr(verbose_level),
-                    "Use e.g. -1 to squelch info, 0 for no debug,  "
-                    "50 for default debug output. 100 max debug.")
+            warning(
+                "Bad format for CALDP_VERBOSITY =",
+                repr(verbose_level),
+                "Use e.g. -1 to squelch info, 0 for no debug,  " "50 for default debug output. 100 max debug.",
+            )
             self.verbose_level = DEFAULT_VERBOSITY_LEVEL
 
     def set_formatter(self, enable_time=True):
         """Set the formatter attribute of `self` to a logging.Formatter and return it."""
         prefix = "%(asctime)s - " if enable_time else ""
-        self.formatter = logging.Formatter(f'{prefix}%(levelname)s - %(message)s')
+        self.formatter = logging.Formatter(f"{prefix}%(levelname)s - %(message)s")
         for handler in self.handlers:
             handler.setFormatter(self.formatter)
         return self.formatter
@@ -167,7 +169,7 @@ class CaldpLogger:
         self.errors = self.warnings = self.infos = self.debugs = 0
 
     def set_verbose(self, level=True):
-        assert -3 <= level <= 100,  "verbosity level must be in range -3..100"
+        assert -3 <= level <= 100, "verbosity level must be in range -3..100"
         old_verbose = self.verbose_level
         if level is True:
             level = DEFAULT_VERBOSITY_LEVEL
@@ -263,10 +265,12 @@ def set_log_time(enable_time=False):
 
 # ===========================================================================
 
+
 class PP:
     """A wrapper to defer pretty printing until after it's known a verbose
     message will definitely be output.
     """
+
     def __init__(self, ppobj):
         self.ppobj = ppobj
 
@@ -278,11 +282,13 @@ class Deferred:
     """A wrapper to delay calling a callable until after it's known a verbose
     message will definitely be output.
     """
+
     def __init__(self, ppobj):
         self.ppobj = ppobj
 
     def __str__(self):
         return str(self.ppobj())
+
 
 # ===========================================================================
 
@@ -294,12 +300,14 @@ def standard_status():
     info(warnings, "warnings")
     info(infos, "infos")
 
+
 # ==============================================================================
 
 
 def srepr(obj):
     """Return the repr() of the str() of obj"""
     return repr(str(obj))
+
 
 # ==============================================================================
 
@@ -311,9 +319,9 @@ def divider(name="", char="-", n=75, func=info, **keys):
     """
     if name:
         n2 = (n - len(name) - 2) // 2
-        func(char*n2, name, char*n2, **keys)
+        func(char * n2, name, char * n2, **keys)
     else:
-        func(char*n, **keys)
+        func(char * n, **keys)
 
 
 # ===================================================================
@@ -322,6 +330,7 @@ def divider(name="", char="-", n=75, func=info, **keys):
 def test():
     from caldp import log
     import doctest
+
     return doctest.testmod(log)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ requires = ["setuptools",
             "wheel"]
 
 build-backend = 'setuptools.build_meta'
+
+[tool.black]
+line-length = 120

--- a/scripts/caldp-image-config
+++ b/scripts/caldp-image-config
@@ -3,6 +3,7 @@
 # Configuration settings used in caldp container image build scripts
 
 # e.g. export CALDP_IMAGE_REPO=jaytmiller/caldp
-export CALDP_IMAGE_REPO=162808325377.dkr.ecr.us-east-1.amazonaws.com/caldp
+# export CALDP_IMAGE_REPO=162808325377.dkr.ecr.us-east-1.amazonaws.com/caldp
+export CALDP_IMAGE_REPO=bhayden/caldp
 export CALDP_IMAGE_TAG=${1:-latest}
 export CALDP_DOCKER_IMAGE=${CALDP_IMAGE_REPO}:${CALDP_IMAGE_TAG}

--- a/tox.ini
+++ b/tox.ini
@@ -86,4 +86,4 @@ skip_install = true
 changedir = .
 description = check code style, e.g. with flake8
 deps = flake8
-commands = flake8 caldp --count --max-line-length=100
+commands = flake8 caldp --count --max-line-length=120


### PR DESCRIPTION
updated pyproject with a black config to allow line lengths of 120. Same for tox.ini so flake8 will allow it. Ran black on all python scripts to reformat and standardize their syntax.