### PR TITLE
Finish caldp-process-aws wrapper function

### DIFF
--- a/scripts/caldp-image-config
+++ b/scripts/caldp-image-config
@@ -3,7 +3,7 @@
 # Configuration settings used in caldp container image build scripts
 
 # e.g. export CALDP_IMAGE_REPO=jaytmiller/caldp
-# export CALDP_IMAGE_REPO=162808325377.dkr.ecr.us-east-1.amazonaws.com/caldp
-export CALDP_IMAGE_REPO=bhayden/caldp
+# export CALDP_IMAGE_REPO=bhayden/caldp
+export CALDP_IMAGE_REPO=162808325377.dkr.ecr.us-east-1.amazonaws.com/caldp
 export CALDP_IMAGE_TAG=${1:-latest}
 export CALDP_DOCKER_IMAGE=${CALDP_IMAGE_REPO}:${CALDP_IMAGE_TAG}

--- a/scripts/caldp-process-aws
+++ b/scripts/caldp-process-aws
@@ -2,9 +2,11 @@
 
 # For non-AWS desktop use based on pip install.  Docker must wrap this.
 
-ipppssoot=$1
-input_path=$2
-output_path=$3
-caldp_config=${4:-caldp-config-aws-crds}
+# caldp-process-aws  <s3_output_path>   <ipppssoot>
+
+output_path=$1
+ipppssoot=$2
+input_path="astroquery:"
+caldp_config=${4:-caldp-config-aws}
 
 caldp-process $ipppssoot  $input_path   $output_path   $caldp_config


### PR DESCRIPTION
Finished caldp-process-aws script,  keeping old interface of caldp-pocess for use by the AWS Batch job definition.
Switched default CALDP_IMAGE_REPO back to AWS ECR for the DMD-TEST prototype.