### PR TITLE
Add env var to customize Docker switches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -384,14 +384,28 @@ Running *caldp-process-aws* does require access to the CRDS and the output bucke
 
 Debugging in the Container
 ++++++++++++++++++++++++++
-Sometimes you want to execute commands in the container environment rather than *caldp-process*. You
-can run any command using *caldp-docker-run-container* which is itself wrapped by *caldp-docker-run-pipeline*.
+Sometimes you want to execute commands other than *caldp-process* in the container environment. You
+can run any command using *caldp-docker-run-container* which is itself normally wrapped by
+*caldp-docker-run-pipeline*.
+
+Before running,  the environment variable *CALDP_DOCKER_RUN_PARS* needs to be defined to add Docker command line
+switches which precede the CALDP image on the `docker run` command line.  It should be defined as follows to e.g.
+enable the interactive debug:
 
 .. code-block:: sh
 
-    # You can run a shell or other alternate program inside the CALDP container like this:
+    export CALDP_DOCKER_RUN_PARS="-it"
 
-    caldp-docker-run-container  /bin/bash  # interactive shell at /home/developer inside the container, nominally as user *developer*.
+Once *CALDP_DOCKER_RUN_PARS* is defined,  you can start an interactive session inside the container like this:
+
+.. code-block:: sh
+
+    caldp-docker-run-container  /bin/bash
+
+The same method can be used to add additional docker configuration parameters for any reason.
+
+*CALDP_DOCKER_RUN_PARS* defaults to `--rm` to do automatic container cleanup during normal non-debug operation.  It
+could also be used to e.g. make a port mapping for JupyterLab by adding:  `-p 8888:8888`.
 
 About CALDP_HOME
 ++++++++++++++++

--- a/scripts/caldp-docker-run-container
+++ b/scripts/caldp-docker-run-container
@@ -55,7 +55,9 @@ else
     MOUNTS="${MOUNTS} --mount type=bind,source=${CRDS_SRC},target=/grp/crds/cache,readonly"
 fi
 
+# -it -p 8888:8888    # for interactive debug and JupyterHub access.
+caldp_docker_run_pars=${CALDP_DOCKER_RUN_PARS:-"--rm"}
 
 # we pass DEV_HOME into the container as an env variable so that the output paths in the message
 # can refer to the local, out-of-container path.
-docker run --rm -it -p 8888:8888 --env DEV_HOME=$DEV_HOME --env CALDP_DOCKER=1 $MOUNTS $CALDP_DOCKER_IMAGE $*
+docker run ${caldp_docker_run_pars}  --env DEV_HOME=$DEV_HOME --env CALDP_DOCKER=1 $MOUNTS $CALDP_DOCKER_IMAGE $*


### PR DESCRIPTION
Added env var CALDP_DOCKER_RUN_PARS to support setting the Docker switches which precede the image name.  This enables turning off both -it and  -p 8888:8888 which were causing problems in the onsite HST HTCondor pipeline;  they are now off by default,  debugging or supporting JupyterHub requires defining this to turn them on as needed.   The only remaining switch on by default is --rm which does automatic Docker container cleanup which should be the non-debug norm.

-it was causing problems with processes due to no TTY. 
-p 8888:8888 was causing problems with multiple processes all wanting port 8888.