### PR TITLE
photutils import fix for the CALDP_20201208_DRZ_final base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN yum install -y \
    libpng-devel \
    libjpeg-devel \
    libcurl-devel \
-   tar
+   tar \
+   patch
 
 # Install fitscut
 COPY scripts/caldp-install-fitscut  .
@@ -83,3 +84,4 @@ RUN mkdir -p /grp/crds/cache && chown -R developer.developer /grp/crds/cache
 
 USER developer
 RUN cd caldp  &&  pip install .[dev,test]
+RUN cd /opt/conda/lib/python3.6/site-packages/photutils && patch -p 0 __init__.py /home/developer/caldp/ascii_fix.patch

--- a/ascii_fix.patch
+++ b/ascii_fix.patch
@@ -1,0 +1,11 @@
+--- __init__.py.orig    2021-01-15 18:46:20.226242517 +0000
++++ __init__.py 2021-01-15 18:46:38.826241089 +0000
+@@ -27,7 +27,7 @@
+ def _get_bibtex():
+     citation_file = os.path.join(os.path.dirname(__file__), 'CITATION.rst')
+ 
+-    with open(citation_file, 'r') as citation:
++    with open(citation_file, 'r', encoding='utf8') as citation:
+         refs = citation.read().split('@software')[1:]
+         if len(refs) == 0:
+             return ''


### PR DESCRIPTION
patches the photutils __init__.py in the container to read the CITATIONS.rst file as utf8