### PR TITLE
Separate tag for docker base image in caldp-image-config

### DIFF
--- a/ascii_fix.patch
+++ b/ascii_fix.patch
@@ -9,3 +9,4 @@
          refs = citation.read().split('@software')[1:]
          if len(refs) == 0:
              return ''
+             

--- a/ascii_fix.patch
+++ b/ascii_fix.patch
@@ -9,4 +9,3 @@
          refs = citation.read().split('@software')[1:]
          if len(refs) == 0:
              return ''
-             

--- a/scripts/caldp-image-config
+++ b/scripts/caldp-image-config
@@ -15,5 +15,6 @@ export CALDP_IMAGE_REPO=alphasentaurii/caldp
 export CALDP_IMAGE_TAG=latest
 export CALDP_DOCKER_IMAGE=${CALDP_IMAGE_REPO}:${CALDP_IMAGE_TAG}
 
+export BASE_IMAGE_TAG=CALDP_20201208_DRZ_final
 # Fundamental calibration s/w image CALDP image inherits from
-export CAL_BASE_IMAGE=stsci/hst-pipeline:${CALDP_IMAGE_TAG}
+export CAL_BASE_IMAGE=stsci/hst-pipeline:${BASE_IMAGE_TAG}


### PR DESCRIPTION
added separate tags for the docker base image and the image that will be created by the user running caldp-image-build