### PR TITLE
bugfixes/file-io

### DIFF
--- a/caldp/create_previews.py
+++ b/caldp/create_previews.py
@@ -185,7 +185,7 @@ def main(ipppssoot, input_uri_prefix, output_uri_prefix):
     """Generates previews based on input and output directories
     according to specified args
     """
-    output_path = file_ops.get_local_outpath(output_uri_prefix, ipppssoot)
+    output_path = messages.get_local_outpath(output_uri_prefix, ipppssoot)
     msg = messages.Messages(output_uri_prefix, output_path, ipppssoot)
     msg.preview_message()
     logger = log.CaldpLogger(enable_console=False, log_file="preview.txt")
@@ -202,22 +202,19 @@ def main(ipppssoot, input_uri_prefix, output_uri_prefix):
     # create previews
     previews = create_previews(input_dir, preview_inputs)
     # upload/copy previews
-    if len(previews) > 0:
-        log.info("Saving previews...")
-        if output_uri_prefix.startswith("s3"):
-            preview_output = process.get_output_path("file:outputs", ipppssoot) + "/previews"
-            os.makedirs(preview_output, exist_ok=True)
-            copy_previews(previews, preview_output)
-            log.info("Uploading previews...")
-            file_ops.tar_outputs(ipppssoot, output_uri_prefix)
-        elif output_uri_prefix.startswith("file"):
-            preview_output = process.get_output_path(output_uri_prefix, ipppssoot) + "/previews"
-            os.makedirs(preview_output, exist_ok=True)
-            copy_previews(previews, preview_output)
-        else:
-            return
+    log.info("Saving previews...")
+    if output_uri_prefix.startswith("s3"):
+        preview_output = process.get_output_path("file:outputs", ipppssoot) + "/previews"
+        os.makedirs(preview_output, exist_ok=True)
+        copy_previews(previews, preview_output)
+        log.info("Uploading previews...")
+        file_ops.tar_outputs(ipppssoot, output_uri_prefix)
+    elif output_uri_prefix.startswith("file"):
+        preview_output = process.get_output_path(output_uri_prefix, ipppssoot) + "/previews"
+        os.makedirs(preview_output, exist_ok=True)
+        copy_previews(previews, preview_output)
     else:
-        log.error("Error - Previews not generated.")
+        return
     del logger
 
 

--- a/caldp/file_ops.py
+++ b/caldp/file_ops.py
@@ -8,6 +8,7 @@ import threading
 from caldp import process
 from caldp import log
 
+
 def get_output_dir(output_uri):
     """Returns full path to output folder """
     if output_uri.startswith("file"):

--- a/caldp/messages.py
+++ b/caldp/messages.py
@@ -7,7 +7,6 @@ import boto3
 import time
 from caldp import process
 from caldp import log
-from caldp import file_ops
 
 
 class Logs:
@@ -22,7 +21,7 @@ class Logs:
                 log_output = os.path.join(self.output_path, "logs")
                 os.makedirs(log_output, exist_ok=True)
             else:
-                log_output = file_ops.get_local_outpath(self.output_uri, self.ipppssoot)
+                log_output = get_local_outpath(self.output_uri, self.ipppssoot)
         elif local is False:
             log_output = self.output_path
         return log_output
@@ -62,7 +61,7 @@ class Logs:
             with open(k, "rb") as f:
                 client.upload_fileobj(f, bucket, obj)
                 log.info(f"\t{v}.")
-                os.remove(k)
+                # os.remove(k)
         log.info("Log files uploaded.")
 
 
@@ -201,6 +200,7 @@ class Messages:
             log.info(f"Dataset synced: {s3_path}")
 
 
+# for pytest cov (create metrics files similar to caldp-process bash script)
 def log_metrics(log_file, metrics):
     res = {}
     res["walltime"] = time.time()
@@ -235,7 +235,7 @@ def log_metrics(log_file, metrics):
 #     os.rmdir(folder)
 #     print("Done.")
 
-
+# primarily for test cov where output_uri is "none"
 def path_finder(input_uri, output_uri_prefix, ipppssoot):
     if output_uri_prefix is None:
         if input_uri.startswith("file"):
@@ -251,21 +251,30 @@ def path_finder(input_uri, output_uri_prefix, ipppssoot):
         output_path = process.get_output_path(output_uri, ipppssoot)
     return output_uri, output_path
 
+# find where to put logs 
+def get_local_outpath(output_uri, ipppssoot):
+    """Returns full path to folder containing output files."""
+    if output_uri.startswith("s3"):
+        local_outpath = process.get_output_path("file:outputs", ipppssoot)
+    else:
+        local_outpath = process.get_output_path(output_uri, ipppssoot)
+    return local_outpath
+
 
 def main(input_uri, output_uri_prefix, ipppssoot):
     """This function is designed to run after calibration has completed."""
     output_uri, output_path = path_finder(input_uri, output_uri_prefix, ipppssoot)
     logs = Logs(output_path, output_uri, ipppssoot)
     logs.copy_logs()
-    msg = Messages(output_uri, output_path, ipppssoot)
-    msg.preview_message()
-    msg.final_message()
     if output_uri.startswith("s3"):
         logs.upload_logs()
         # clean_up(ipppssoot, IO="outputs")
         # clean_up(ipppssoot, IO="messages")
         # if not input_uri.startswith("file"):
         #     clean_up(ipppssoot, IO="inputs")
+    msg = Messages(output_uri, output_path, ipppssoot)
+    msg.preview_message()
+    msg.final_message()
 
 
 def cmd(argv):

--- a/caldp/messages.py
+++ b/caldp/messages.py
@@ -251,7 +251,8 @@ def path_finder(input_uri, output_uri_prefix, ipppssoot):
         output_path = process.get_output_path(output_uri, ipppssoot)
     return output_uri, output_path
 
-# find where to put logs 
+
+# find where to put logs
 def get_local_outpath(output_uri, ipppssoot):
     """Returns full path to folder containing output files."""
     if output_uri.startswith("s3"):

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -338,12 +338,11 @@ def file_ops_check(ipppssoot, input_uri, output_uri):
     Workaround to improve test coverage when s3 bucket access is unavailable.
     """
     if output_uri.startswith("file"):
-        tar, file_list, local_outpath = file_ops.tar_outputs(ipppssoot, output_uri)
-        output_path = process.get_output_path(output_uri, ipppssoot)
-        assert os.path.abspath(output_path) == local_outpath
+        tar, file_list = file_ops.tar_outputs(ipppssoot, output_uri)
         assert len(file_list) > 0
-        assert os.path.exists(tar)
-        actual_tarfiles = list_files(os.path.dirname(tar), ipppssoot)
+        tarpath = os.path.join("outputs", tar)
+        assert os.path.exists(tarpath)
+        actual_tarfiles = list_files(os.path.dirname(tarpath), ipppssoot)
         return actual_tarfiles
 
         # file_list.append(tar)
@@ -510,7 +509,7 @@ def check_messages(ipppssoot, output_uri, status):
 
 
 def message_status_check(input_uri, output_uri, ipppssoot):
-    output_path = file_ops.get_local_outpath(output_uri, ipppssoot)
+    output_path = messages.get_local_outpath(output_uri, ipppssoot)
     msg = messages.Messages(output_uri, output_path, ipppssoot)
     assert msg.msg_dir == os.path.join(os.getcwd(), "messages")
     assert msg.stat == 0


### PR DESCRIPTION
1. file_ops.py: set tarfile's top dir as ipst folder (so it extracts as: ipst/ipst.tar, log.txt)
2. create_previews.py: removed min 1 preview req for executing copy/upload condition (this bug prevented the entire upload sequence from happening in cases where 0 previews are generated)
3. moved `get_local_outpath()` from file_ops to messages (no longer needed by file_ops funcs), added `get_output_dir()` to file_ops.py for proper file structure in tars (see #1)
4. changed print statements to log outputs (some info wasn't getting logged)
5. messages.py: logs upload before final message execution (in case of error) 
6. process.py: s3 input string accepts uri with or without the trailing slash:  s3://bucket/prefix/ and s3://bucket/prefix
7. adjusted pytest cov according to above changes
8. ran black and flake8 checks