### PR TITLE
removed latest from GA testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [stable]
 
     steps:
       - name: set up python 3.6.10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable]
+        HSTCAL: [CALDP_20201208_DRZ_final]
 
     steps:
       - name: set up python 3.6.10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [sCALDP_20201208_DRZ_final]
 
     steps:
       - name: checkout code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [sCALDP_20201208_DRZ_final]
+        HSTCAL: [CALDP_20201208_DRZ_final]
 
     steps:
       - name: checkout code


### PR DESCRIPTION
The goal of testing in this repo is to test our wrappers around the calibration code. However, by using the "latest" and even "stable" versions of the base stsci-pipeline docker image, we are also testing unreleased code against the operational HST CRDS context. So we should really be pinning the calibration code and CRDS contexts until we're ready to update them, to isolate failures in our code from failures due to combinations of the calibration code and CRDS. 