### PR TITLE
removed latest base image from testing matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [stable]
 
     steps:
       - name: set up python 3.6.10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [stable]
 
     steps:
       - name: checkout code


### PR DESCRIPTION
the purpose of these tests is to test our wrappers around the calibration code; however, by using "latest", we inadvertently test the latest calibration code against the operational CRDS context, which will periodically fail for reasons outside our control.

We can't get rid of "stable" at the moment because in astroconda, the caldp envs have different names than they do on dockerhub, unless the names are "stable" or "latest". So, the safest and easiest thing to do at the moment is only test against stable.