### PR TITLE
Bugfix/header basename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [stable]
 
     steps:
       - name: set up python 3.6.10

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -217,11 +217,11 @@ class InstrumentManager:
 
     def raw_files(self, files):
         """Return each name string in `files` with includes the substring '_raw'."""
-        return [f for f in files if "_raw" in f]
+        return [os.path.basename(f) for f in files if "_raw" in f]
 
     def assoc_files(self, files):
         """Return each name string in `files` which ends with '_asn.fits'."""
-        return [f for f in files if f.endswith("_asn.fits")]
+        return [os.path.basename(f) for f in files if f.endswith("_asn.fits")]
 
     def unassoc_files(self, files):  # can be overriden by subclasses
         """Overridable,  same as raw_files() by default."""


### PR DESCRIPTION
using os.path.basename() for files that are passed directly to the calibration software, as otherwise the full paths are put into the fits headers.