### PR TITLE
Bugfix/header basename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        HSTCAL: [stable, latest]
+        HSTCAL: [stable]
 
     steps:
       - name: set up python 3.6.10

--- a/caldp/create_previews.py
+++ b/caldp/create_previews.py
@@ -191,7 +191,7 @@ def main(ipppssoot, input_uri_prefix, output_uri_prefix):
     logger = log.CaldpLogger(enable_console=False, log_file="preview.txt")
     input_dir = file_ops.get_input_path(input_uri_prefix, ipppssoot)
     # append process.txt to trailer file
-    file_ops.append_trailer(input_dir, output_path, ipppssoot)
+    # file_ops.append_trailer(input_dir, output_path, ipppssoot)
     input_paths = get_inputs(ipppssoot, input_dir)
     instr = process.get_instrument(ipppssoot)
     preview_inputs = get_preview_inputs(instr, input_paths)

--- a/caldp/file_ops.py
+++ b/caldp/file_ops.py
@@ -21,7 +21,7 @@ def get_input_path(input_uri, ipppssoot, make=False):
     return input_path
 
 
-def append_trailer(input_path, output_path, ipppssoot): #pragma: no cover
+def append_trailer(input_path, output_path, ipppssoot):  # pragma: no cover
     """Fetch process log and append to trailer file
     Note: copies trailer file from inputs directory
     and copies to outputs directory prior to appending log

--- a/caldp/file_ops.py
+++ b/caldp/file_ops.py
@@ -21,7 +21,7 @@ def get_input_path(input_uri, ipppssoot, make=False):
     return input_path
 
 
-def append_trailer(input_path, output_path, ipppssoot):
+def append_trailer(input_path, output_path, ipppssoot): #pragma: no cover
     """Fetch process log and append to trailer file
     Note: copies trailer file from inputs directory
     and copies to outputs directory prior to appending log

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -217,11 +217,11 @@ class InstrumentManager:
 
     def raw_files(self, files):
         """Return each name string in `files` with includes the substring '_raw'."""
-        return [f for f in files if "_raw" in f]
+        return [os.path.basename(f) for f in files if "_raw" in f]
 
     def assoc_files(self, files):
         """Return each name string in `files` which ends with '_asn.fits'."""
-        return [f for f in files if f.endswith("_asn.fits")]
+        return [os.path.basename(f) for f in files if f.endswith("_asn.fits")]
 
     def unassoc_files(self, files):  # can be overriden by subclasses
         """Overridable,  same as raw_files() by default."""

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -621,8 +621,8 @@ class StisManager(InstrumentManager):
         -------
         None
         """
-        raw = [f for f in files if f.endswith("_raw.fits")]
-        wav = [f for f in files if f.endswith("_wav.fits")]
+        raw = [os.path.basename(f) for f in files if f.endswith("_raw.fits")]
+        wav = [os.path.basename(f) for f in files if f.endswith("_wav.fits")]
         if raw:
             self.track_versions(files, "_raw")
             self.run(self.stage1, *raw)
@@ -632,7 +632,7 @@ class StisManager(InstrumentManager):
 
     def raw_files(self, files):
         """Returns only '_raw.fits', '_wav.fits', or '_tag.fits' members of `files`."""
-        return [f for f in files if f.endswith(("_raw.fits", "_wav.fits", "_tag.fits"))]
+        return [os.path.basename(f) for f in files if f.endswith(("_raw.fits", "_wav.fits", "_tag.fits"))]
 
 
 # ............................................................................

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -34,7 +34,7 @@ RESULTS = [
 1159 inputs/j8cb01u2q_raw_thumb.jpg
 18748 inputs/j8cb01u3q_flt.jpg
 1083 inputs/j8cb01u3q_flt_thumb.jpg
-16493 inputs/j8cb010b0.tra
+62666 inputs/j8cb010b0.tra
 51840 inputs/j8cb01u3q_flt_hlet.fits
 51840 inputs/j8cb01u2q_flt_hlet.fits
 15963840 inputs/j8cb010b1_drz.fits
@@ -71,7 +71,7 @@ RESULTS = [
 10535040 outputs/j8cb010b0/j8cb010b1_crj.fits
 5166 outputs/j8cb010b0/j8cb010b1.tra
 11520 outputs/j8cb010b0/j8cb010b0_asn.fits
-20740 outputs/j8cb010b0/j8cb010b0.tra
+62666 outputs/j8cb010b0/j8cb010b0.tra
 """,
     ),
     (
@@ -161,7 +161,7 @@ RESULTS = [
 2058 ib8t01htq_raw_thumb.jpg
 46513 ib8t01hwq_ima.jpg
 1859 ib8t01hwq_ima_thumb.jpg
-16110 ib8t01010.tra
+86860 ib8t01010.tra
 8640 ib8t01hwq_flt_hlet.fits
 8640 ib8t01htq_flt_hlet.fits
 12654720 ib8t01010_drz.fits
@@ -200,17 +200,17 @@ RESULTS = [
 12654720 outputs/ib8t01010/ib8t01010_drz.fits
 4733 outputs/ib8t01010/ib8t01htq.tra
 11520 outputs/ib8t01010/ib8t01010_asn.fits
-16110 outputs/ib8t01010/ib8t01010.tra
+86860 outputs/ib8t01010/ib8t01010.tra
         """,
     ),  # wfc3 and acs singletons
     (
         "ibc604b9q",
         """
-927 ibc604b9q.tra
+828 ibc604b9q.tra
 32518080 ibc604b9q_raw.fits
 221702 ibc604b9q_raw.jpg
 842 ibc604b9q_raw_thumb.jpg
-5889 outputs/ibc604b9q/ibc604b9q.tra
+828 outputs/ibc604b9q/ibc604b9q.tra
 32518080 outputs/ibc604b9q/ibc604b9q_raw.fits
 842 outputs/ibc604b9q/ibc604b9q_raw_thumb.jpg
 221702 outputs/ibc604b9q/ibc604b9q_raw.jpg
@@ -223,10 +223,10 @@ RESULTS = [
 7289 j8f54obeq_raw_thumb.jpg
 178971 j8f54obeq_flt.jpg
 7354 j8f54obeq_flt_thumb.jpg
-3095 j8f54obeq.tra
+2732 j8f54obeq.tra
 10532160 j8f54obeq_flt.fits
 2257920 j8f54obeq_raw.fits
-9658 outputs/j8f54obeq/j8f54obeq.tra
+2732 outputs/j8f54obeq/j8f54obeq.tra
 2257920 outputs/j8f54obeq/j8f54obeq_raw.fits
 10532160 outputs/j8f54obeq/j8f54obeq_flt.fits
 7289 outputs/j8f54obeq/j8f54obeq_raw_thumb.jpg


### PR DESCRIPTION
* run the calibration code on the just the filenames instead of fullpaths. 
* this seems to change the way the calibration code handles trailer files, and for the time being I've commented out appending 
* the caldp.process log file (which duplicates a lot of information, but also does add some caldp logging...). 
fixed the tests