### PR TITLE
Exit status improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ crds_cache
 .bash_history
 .vscode
 .python_history
+
+.eggs

--- a/caldp/create_previews.py
+++ b/caldp/create_previews.py
@@ -11,7 +11,9 @@ from astropy.io import fits
 
 from caldp import log
 from caldp import process
-from caldp import file_ops, messages
+from caldp import file_ops
+from caldp import messages
+from caldp import sysexit
 
 # -------------------------------------------------------------------------------------------------------
 
@@ -236,4 +238,5 @@ def cmdline():
 
 
 if __name__ == "__main__":
-    cmdline()
+    with sysexit.exit_receiver():
+        cmdline()

--- a/caldp/exit_codes.py
+++ b/caldp/exit_codes.py
@@ -1,0 +1,141 @@
+"""These numerical values are returned by CALDP as process exit status.
+
+This file should be shared/coordinated *verbatim* with CALCLOUD to ensure that
+CALCLOUD correctly identifies and handles exit status coming from CALDP.
+
+The intent of these codes is to identify specific error cases defined by CALDP.
+
+Any errors not explicitly handled by CALDP are intended to be mapped to
+generic values of 0 or 1 to prevent conflicts with these codes.
+"""
+import sys
+
+_EXIT_CODES = dict(
+    SUCCESS=0,
+    GENERIC_ERROR=1,
+    CMDLINE_ERROR=2,
+    INPUT_TAR_FILE_ERROR=21,
+    ASTROQUERY_ERROR=22,
+    STAGE1_ERROR=23,
+    STAGE2_ERROR=24,
+    S3_UPLOAD_ERROR=25,
+    S3_DOWNLOAD_ERROR=26,
+    BESTREFS_ERROR=27,
+    CREATE_PREVIEWS_ERROR=28,
+    SUBPROCESS_MEMORY_ERROR=31,  # See caldp-process for this
+    CALDP_MEMORY_ERROR=32,
+    CONTAINER_MEMORY_ERROR=33,
+)
+
+
+_NAME_EXPLANATIONS = dict(
+    SUCCESS="Processing completed successfully.",
+    GENERIC_ERROR="An error with no specific CALDP handling occurred somewhere.",
+    CMDLINE_ERROR="The program command line invocation was incorrect.",
+    INPUT_TAR_FILE_ERROR="An error occurred locating or untarring the inputs tarball.",
+    ASTROQUERY_ERROR="An error occurred downloading astroqery: inputs",
+    STAGE1_ERROR="An error occurred in this instrument's stage1 processing step. e.g. calxxx",
+    STAGE2_ERROR="An error occurred in this instrument's stage2 processing step, e.g astrodrizzle",
+    S3_UPLOAD_ERROR="An error occurred uploading the outputs tarball to S3.",
+    S3_DOWNLOAD_ERROR="An error occurred downloading inputs from S3.",
+    BESTREFS_ERROR="An error occurred computing or downloading CRDS reference files.",
+    CREATE_PREVIEWS_ERROR="An error occurrred creating preview files for processed data.",
+    # Potentially see caldp-process bash script for this
+    SUBPROCESS_MEMORY_ERROR="A Python MemoryError was detected by scanning the process.txt log.",
+    CALDP_MEMORY_ERROR="CALDP generated a Python MemoryError during processing or preview creation.",
+    # This is never directly returned.  It's intended to be used to trigger a container memory limit
+    CONTAINER_MEMORY_ERROR="The Batch/ECS container runtime killed the job due to memory limits.",
+)
+
+_CODE_TO_NAME = dict()
+
+# Set up original module global variables / named constants
+for (name, code) in _EXIT_CODES.items():
+    globals()[name] = code
+    _CODE_TO_NAME[code] = name
+    _CODE_TO_NAME[str(code)] = name
+    assert name in _NAME_EXPLANATIONS
+
+
+def explain(exit_code):
+    """Return the text explanation for the specified `exit_code`.
+
+    >>> explain(SUCCESS)
+    'EXIT SUCCESS[0]: Processing completed successfully.'
+
+    >>> explain("SUCCESS")
+    'EXIT SUCCESS[0]: Processing completed successfully.'
+
+    >>> explain(GENERIC_ERROR)
+    'EXIT GENERIC_ERROR[1]: An error with no specific CALDP handling occurred somewhere.'
+
+    >>> explain(SUBPROCESS_MEMORY_ERROR)
+    'EXIT SUBPROCESS_MEMORY_ERROR[31]: A Python MemoryError was detected by scanning the process.txt log.'
+    """
+    if exit_code in _CODE_TO_NAME:
+        name = _CODE_TO_NAME[exit_code]
+        explanation = _NAME_EXPLANATIONS[name]
+    elif exit_code in _NAME_EXPLANATIONS:
+        name = exit_code
+        exit_code = globals()[name]
+        explanation = _NAME_EXPLANATIONS[name]
+    else:
+        raise ValueError("Invalid exit_code: " + repr(exit_code))
+    return f"EXIT {name}[{exit_code}]: {explanation}"
+
+
+def print_explanations(error_codes):
+    """Print out the text explanation of each error code in `error_codes`.
+
+    >>> print_explanations([32])
+    EXIT CALDP_MEMORY_ERROR[32]: CALDP generated a Python MemoryError during processing or preview creation.
+    """
+    for code in error_codes:
+        print(explain(code))
+
+
+def is_memory_error(exit_code):
+    """Return  True IFF `exit_code` indicates some kind of memory error.
+
+    exit_code may be specified as a name string or integer exit code.
+
+    >>> is_memory_error(GENERIC_ERROR)
+    False
+
+    >>> is_memory_error(SUBPROCESS_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error(CALDP_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error(CONTAINER_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error("GENERIC_ERROR")
+    False
+
+    >>> is_memory_error("SUBPROCESS_MEMORY_ERROR")
+    True
+    """
+    memory_error_names = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
+    return (exit_code in [globals()[name] for name in memory_error_names]) or (exit_code in memory_error_names)
+
+
+def test():
+    import doctest
+
+    try:
+        from caldp import exit_codes
+    except ImportError:
+        from calcloud import exit_codes
+    return doctest.testmod(exit_codes)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "test":
+        print(test())
+    elif len(sys.argv) >= 2 and sys.argv[1] == "explain":
+        print_explanations(sys.argv[2:])
+    else:
+        print("usage: python -m caldp.exit_codes [test|explain] [explain_codes...]")
+        sys.exit(globals()["CMDLINE_ERROR"])  # the things we do for flake8...

--- a/caldp/log.py
+++ b/caldp/log.py
@@ -269,11 +269,16 @@ def infos():
     return THE_LOGGER.infos
 
 
+CONSOLE_OUTPUT_STREAM = sys.stderr
+
+
 def set_test_mode():
     """Route log messages to standard output for testing with doctest."""
+    global CONSOLE_OUTPUT_STREAM
     remove_console_handler()
     add_console_handler(stream=sys.stdout)
     set_log_time(False)
+    CONSOLE_OUTPUT_STREAM = sys.stdout
 
 
 def set_log_time(enable_time=False):

--- a/caldp/messages.py
+++ b/caldp/messages.py
@@ -99,13 +99,13 @@ class Messages:
         for f in previous_files:
             self.remove_message(f)
 
-    def start_message(self):
+    def init(self):
         os.makedirs(self.msg_dir, exist_ok=True)
         self.clear_messages()
         if self.stat == 0:
             self.name = f"submit-{self.ipppssoot}"
             self.file = f"{self.msg_dir}/{self.name}"
-            self.write_message()
+            # self.write_message()  # submit-xxx is written by CALCLOUD
             self.stat += 1  # increment status
         return self
 

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -30,7 +30,10 @@ except ImportError:
 
 from crds.bestrefs import bestrefs
 
-from caldp import log, messages
+from caldp import log
+from caldp import messages
+from caldp import exit_codes
+from caldp import sysexit
 
 # import caldp     (see track_versions)
 
@@ -163,7 +166,8 @@ class InstrumentManager:
     delete_endings : list of str
         (class) Endings of filenames to remove prior to previews or S3 uploads.
     ignore_err_nums : list of int
-        (class) Nonzero calibration error codes which should be ignored.
+        (class) Nonzero calibration error codes which should be ignored. Different than
+        CALDP codes in error_codes.py.
     stage1 : str
         (class) Program name for basic calibration and all association or unassociated files.
     stage2 : str
@@ -250,7 +254,7 @@ class InstrumentManager:
         log.info(dash * 80)
         log.info(dash * 5, self.ipppssoot, msg, dash * (dashes - 6 - len(self.ipppssoot) - len(msg) - 1))
 
-    def run(self, cmd, *args):
+    def run(self, exit_code, cmd, *args):
         """Run the subprocess string `cmd`,  appending any extra values
         defined by `args`.
 
@@ -278,12 +282,18 @@ class InstrumentManager:
         """
         cmd = tuple(cmd.split()) + args  # Handle stage values with switches.
         self.divider("Running:", cmd)
-        err = subprocess.call(cmd)
-        if err in self.ignore_err_nums:
-            log.info("Ignoring error status =", err)
-        elif err:
-            log.error(self.ipppssoot, "Command:", repr(cmd), "exited with error status:", err)
-            sys.exit(1)
+        with sysexit.exit_on_exception(exit_code, self.ipppssoot, "Command:", repr(cmd)):
+            err = subprocess.call(cmd)
+            if err in self.ignore_err_nums:
+                log.info("Ignoring error status =", err)
+            elif err:
+                raise RuntimeError(f"Subprocess returned with non-zero status = {err}")
+
+    def run_stage1(self, *args):
+        return self.run(exit_codes.STAGE1_ERROR, self.stage1, *args)
+
+    def run_stage2(self, *args):
+        return self.run(exit_codes.STAGE2_ERROR, self.stage2, *args)
 
     # .............................................................
 
@@ -348,7 +358,6 @@ class InstrumentManager:
         Extracts, then saves file paths to a sorted list.
         Returns sorted list of file paths (`input_files`)
         """
-        client = boto3.client("s3")
         key = self.ipppssoot + ".tar.gz"
         s3_path = self.input_uri.replace("s3://", "").split("/")
         bucket, prefix = s3_path[0], "/".join(s3_path[1:])
@@ -357,14 +366,19 @@ class InstrumentManager:
         else:  # remove trailing slash from prefix if there is one
             obj = prefix.strip("/") + "/" + key
         self.divider(f"Retrieving tarfile: s3://{bucket}/{obj}")
-        with open(key, "wb") as f:
-            client.download_fileobj(bucket, obj, f)  # 'odfa0120.tar.gz'
-        self.divider(f"Extracting files from {key}")
-        with tarfile.open(key, "r:gz") as tar_ref:
-            tar_ref.extractall()
-            # then delete tars
-            os.remove(key)
+        with sysexit.exit_on_exception(
+            exit_codes.S3_DOWNLOAD_ERROR, f"Failed downloading or extracting s3://{bucket}/{obj}"
+        ):
+            client = boto3.client("s3")
+            with open(key, "wb") as f:
+                client.download_fileobj(bucket, obj, f)  # 'odfa0120.tar.gz'
 
+        with sysexit.exit_on_exception(exit_codes.INPUT_TAR_FILE_ERROR, "Failed extracting inputs from", key):
+            self.divider(f"Extracting files from {key}")
+            with tarfile.open(key, "r:gz") as tar_ref:
+                tar_ref.extractall()
+                # then delete tars
+        os.remove(key)
         self.divider("Gathering fits files for calibration")
         search_fits = f"{input_path}/{self.ipppssoot.lower()[0:5]}*.fits"
         self.divider("Finding input data using:", repr(search_fits))
@@ -382,10 +396,13 @@ class InstrumentManager:
             Local file system paths of files which were downloaded for `ipppssoot`,
             some of which will be selected for calibration processing.
         """
-        self.divider("Retrieving data files for:", self.download_suffixes)
-        files = retrieve_observation(self.ipppssoot, suffix=self.download_suffixes)
-        self.divider("Download data complete.")
-        return list(sorted([os.path.abspath(f) for f in files]))
+        with sysexit.exit_on_exception(
+            exit_codes.ASTROQUERY_ERROR, "Astroquery exception downloading suffixes:", self.download_suffixes
+        ):
+            self.divider("Retrieving data files for:", self.download_suffixes)
+            files = retrieve_observation(self.ipppssoot, suffix=self.download_suffixes)
+            self.divider("Download data complete.")
+            return list(sorted([os.path.abspath(f) for f in files]))
 
     def find_input_files(self):
         """Scrape the input_uri for the needed input_files.
@@ -407,11 +424,16 @@ class InstrumentManager:
         cwd = os.getcwd()
         search_tar = f"{base_path}/{self.ipppssoot.lower()[0:5]}*.tar.gz"
         tar_files = glob.glob(search_tar)
-        if len(tar_files) == 1:
-            log.info("Extracting inputs from: ", tar_files)
-            os.chdir(base_path)
-            with tarfile.open(tar_files[0], "r:gz") as tar_ref:
-                tar_ref.extractall()
+        with sysexit.exit_on_exception(exit_codes.INPUT_TAR_FILE_ERROR, "Failed extracting inputs from", tar_files):
+            if len(tar_files) == 0:
+                raise RuntimeError(f"No input tar files for: {repr(search_tar)}")
+            elif len(tar_files) == 1:
+                log.info("Extracting inputs from: ", tar_files)
+                os.chdir(base_path)
+                with tarfile.open(tar_files[0], "r:gz") as tar_ref:
+                    tar_ref.extractall()
+            else:
+                raise RuntimeError(f"Too many tar files for: {repr(search_tar)} = {tar_files}")
         os.chdir(cwd)
         # get input files
         search_str = f"{base_path}/{self.ipppssoot.lower()[0:5]}*.fits"
@@ -477,15 +499,16 @@ class InstrumentManager:
         -------
         None
         """
-        self.divider("Computing bestrefs and downloading references.", files)
-        bestrefs_files = self.raw_files(files)
-        # Only sync reference files if the cache is read/write.
-        bestrefs.assign_bestrefs(
-            bestrefs_files,
-            context=os.environ.get("CRDS_CONTEXT", default=None),
-            sync_references=os.environ.get("CRDS_READONLY_CACHE", "0") != "1",
-        )
-        self.divider("Bestrefs complete.")
+        with sysexit.exit_on_exception(exit_codes.BESTREFS_ERROR, "Failed computing or downloading reference files."):
+            self.divider("Computing bestrefs and downloading references.", files)
+            bestrefs_files = self.raw_files(files)
+            # Only sync reference files if the cache is read/write.
+            bestrefs.assign_bestrefs(
+                bestrefs_files,
+                context=os.environ.get("CRDS_CONTEXT", default=None),
+                sync_references=os.environ.get("CRDS_READONLY_CACHE", "0") != "1",
+            )
+            self.divider("Bestrefs complete.")
 
     def set_env_vars(self):
         """looks for an ipppssoot_cal_env.txt file and sets the key=value
@@ -523,15 +546,15 @@ class InstrumentManager:
         self.track_versions(files)
         assoc = self.assoc_files(files)
         if assoc:
-            self.run(self.stage1, *assoc)
+            self.run_stage1(*assoc)
             if self.stage2:
-                self.run(self.stage2, *assoc)
+                self.run_stage2(*assoc)
             return
         unassoc = self.unassoc_files(files)
         if unassoc:
-            self.run(self.stage1, *unassoc)
+            self.run_stage1(*unassoc)
             if self.stage2:
-                self.run(self.stage2, *unassoc)
+                self.run_stage2(*unassoc)
             return
 
     def output_files(self):
@@ -657,10 +680,10 @@ class StisManager(InstrumentManager):
         wav = [os.path.basename(f) for f in files if f.endswith("_wav.fits")]
         if raw:
             self.track_versions(files, "_raw")
-            self.run(self.stage1, *raw)
+            self.run_stage1(*raw)
         else:
             self.track_versions(files, "_wav")
-            self.run(self.stage1, *wav)
+            self.run_stage1(*wav)
 
     def raw_files(self, files):
         """Returns only '_raw.fits', '_wav.fits', or '_tag.fits' members of `files`."""
@@ -718,15 +741,19 @@ def process(ipppssoot, input_uri, output_uri):
     -------
     None
     """
+    process_log = log.CaldpLogger(enable_console=False, log_file="process.txt")
+
     if output_uri is None:
         output_uri, output_path = messages.path_finder(input_uri, output_uri, ipppssoot)
     output_path = get_output_path(output_uri, ipppssoot)
+
     msg = messages.Messages(output_uri, output_path, ipppssoot)
-    msg.start_message()  # submit-ipst
-    process_log = log.CaldpLogger(enable_console=False, log_file="process.txt")
+    msg.init()
     msg.process_message()  # processing-ipst
+
     manager = get_instrument_manager(ipppssoot, input_uri, output_uri)
     manager.main()
+
     del process_log
 
 
@@ -817,5 +844,6 @@ def main(argv):
 if __name__ == "__main__":
     if len(sys.argv) < 4:
         print("usage:  process.py <input_uri>  <output_uri>  <ipppssoot's...>")
-        sys.exit(1)
-    main(sys.argv)
+        sys.exit(exit_codes.CMDLINE_ERROR)
+    with sysexit.exit_receiver():
+        main(sys.argv)

--- a/caldp/sysexit.py
+++ b/caldp/sysexit.py
@@ -1,0 +1,204 @@
+"""This module defines context managers which are used to trap exceptions
+and exit Python cleanly with specific exit_codes which are then seen as
+the numerical exit status of the process and ultimately Batch job.
+
+The exit_on_exception() context manager is used to bracket a block of code
+by mapping all exceptions onto some log output and a call to sys.exit():
+
+    with exit_on_exception(exit_codes.SOME_CODE, "Parts of the ERROR", "message output", "on exception."):
+        ... the code you're trapping to SOME_CODE when things go wrong ...
+
+The exit_on_exception() manager also enables simulating errors by defining the
+CALDP_SIMULATE_ERROR=N environment variable.  When the manager is called with a
+code matching CALDP_SIMULATE_ERROR, instead of running the code block it fakes
+an exception by performing the corresponding log output and sys.exit() call.  A
+few error codes are simulated more directly, particularly memory errors.
+
+The exit_receiver() manager is used to bracket the top level of your code,
+nominally main(), and land the SystemExit() exception raised by
+exit_on_exception() after the stack has been unwound and cleanup functions
+performed.  exit_receiver() then exits Python with the error code originally
+passed into exit_on_exception().
+
+>>> from caldp import log
+>>> log.set_test_mode()
+>>> log.reset()
+"""
+import sys
+import os
+import contextlib
+import traceback
+import resource
+
+from caldp import log
+from caldp import exit_codes
+
+# ==============================================================================
+
+
+@contextlib.contextmanager
+def exit_on_exception(exit_code, *args):
+    """exit_on_exception is a context manager which issues an error message
+    based on *args and then does sys.exit(exit_code) if an exception is
+    raised within the corresponding "with block".
+
+    >>> with exit_on_exception(1, "As expected", "it did not fail."):
+    ...    print("do it.")
+    do it.
+
+    >>> try: #doctest: +ELLIPSIS
+    ...    with exit_on_exception(2, "As expected", "it failed."):
+    ...        raise Exception("It failed!")
+    ...        print("do it.")
+    ... except SystemExit:
+    ...    log.divider()
+    ...    print("Trapping SystemExit normally caught by log.exit_reciever() at top level.")
+    INFO - ----------------------------- Fatal Exception -----------------------------
+    ERROR - EXIT CMDLINE_ERROR[2]: The program command line invocation was incorrect.
+    ERROR - As expected it failed.
+    ERROR - Traceback (most recent call last):
+    ERROR -   File ".../caldp/caldp/sysexit.py", line ..., in exit_on_exception
+    ERROR -     yield
+    ERROR -   File "<doctest caldp.sysexit.exit_on_exception[1]>", line ..., in <module>
+    ERROR -     raise Exception("It failed!")
+    ERROR - Exception: It failed!
+    INFO - ---------------------------------------------------------------------------
+    Trapping SystemExit normally caught by log.exit_reciever() at top level.
+
+    Never printed 'do it.'  SystemExit is caught for testing.
+
+    If CALDP_SIMULATE_ERROR is set to one of exit_codes, it will cause the
+    with exit_on_exception() block to act as if a failure has occurred:
+
+    >>> os.environ["CALDP_SIMULATE_ERROR"] = "2"
+    >>> try: #doctest: +ELLIPSIS
+    ...    with exit_on_exception(2, "As expected a matching failure was simulated"):
+    ...        print("should not see this")
+    ... except SystemExit:
+    ...    pass
+    INFO - ----------------------------- Fatal Exception -----------------------------
+    ERROR - EXIT CMDLINE_ERROR[2]: The program command line invocation was incorrect.
+    ERROR - As expected a matching failure was simulated
+    ERROR - Traceback (most recent call last):
+    ERROR -   File ".../caldp/caldp/sysexit.py", line ..., in exit_on_exception
+    ERROR -     raise RuntimeError(f"Simulating error = {simulated_code}")
+    ERROR - RuntimeError: Simulating error = 2
+
+    >>> with exit_on_exception(3, "Only matching error codes are simulated."):
+    ...    print("should print normally")
+    should print normally
+
+    >>> del os.environ["CALDP_SIMULATE_ERROR"]
+    """
+    simulated_code = int(os.environ.get("CALDP_SIMULATE_ERROR", "0"))
+    try:
+        if simulated_code == exit_codes.CALDP_MEMORY_ERROR:
+            raise MemoryError("Simulated CALDP memory error.")
+        elif simulated_code == exit_codes.SUBPROCESS_MEMORY_ERROR:
+            print("MemoryError", file=sys.stderr)
+            raise MemoryError("Simulated subprocess memory error.")
+        elif simulated_code == exit_codes.CONTAINER_MEMORY_ERROR:
+            log.info("Simulating hard memory error by allocating memory")
+            _ = bytearray(1024 * 2 ** 30)  # 1024G XXXX NOT WORKING
+        elif exit_code == simulated_code:
+            raise RuntimeError(f"Simulating error = {simulated_code}")
+        yield
+    # don't mask memory errors or nested exit_on_exception handlers
+    except SystemExit as exc:
+        _report_exception(exc.code)
+        raise
+    except MemoryError:
+        _report_exception(exit_codes.CALDP_MEMORY_ERROR)
+        raise
+    except Exception:
+        _raise_exit_exception(exit_code, *args)
+
+
+def _raise_exit_exception(exit_code, *args):
+    """Call this function to terminate program execution with the error message
+    defined by `*args` eventually exiting with `exit_code`.
+
+    Each element of positional parameters *args is first converted to a string,
+    then all elements are joined seperated by spaces to form the completed'
+    exception ERROR message.
+
+    >>> try:
+    ...    _raise_exit_exception(exit_codes.GENERIC_ERROR, "this is a test exit exception.")
+    ...    print("won't get here.")
+    ... except SystemExit:
+    ...    log.divider()
+    ...    print("Trapping SystemExit normally caught by log.exit_reciever() at top level.")
+    INFO - ----------------------------- Fatal Exception -----------------------------
+    ERROR - EXIT GENERIC_ERROR[1]: An error with no specific CALDP handling occurred somewhere.
+    ERROR - this is a test exit exception.
+    INFO - ---------------------------------------------------------------------------
+    Trapping SystemExit normally caught by log.exit_reciever() at top level.
+    """
+    _report_exception(exit_code, *args)
+    sys.exit(exit_code)
+
+
+def _report_exception(exit_code, *args):
+    log.divider("Fatal Exception")
+    log.error(exit_codes.explain(exit_code))
+    if args:
+        log.error(*args)
+    for line in traceback.format_exc().splitlines():
+        if line != "NoneType: None":
+            log.error(line)
+
+
+@contextlib.contextmanager
+def exit_receiver():
+    """Use this contextmanager to bracket your top level code and land the sys.exit()
+    exceptions thrown by _raise_exit_exception() and exit_on_exception().
+
+    This program structure enables sys.exit() to fully unwind the stack doing
+    cleanup, then calls the low level os._exit() function which does no cleanup
+    as the "last thing".
+
+    If SystemExit is not raised by the code nested in the "with" block then
+    exit_receiver() essentially does nothing.
+
+    The program is exited with the numerical code passed to sys.exit().
+    """
+    try:
+        log.info("Container memory limit is: ", get_linux_memory_limit())
+        yield
+    except SystemExit as exc:
+        os._exit(exc.code)
+    except MemoryError:
+        os._exit(exit_codes.CALDP_MEMORY_ERROR)
+    except Exception:
+        os._exit(exit_codes.GENERIC_ERROR)
+    os._exit(exit_codes.SUCCESS)
+
+
+def get_linux_memory_limit():
+    """This generally shows the full address space by default."""
+    if os.path.isfile("/sys/fs/cgroup/memory/memory.limit_in_bytes"):
+        with open("/sys/fs/cgroup/memory/memory.limit_in_bytes") as limit:
+            mem = int(limit.read())
+        return mem
+    else:
+        raise RuntimeError("get_linux_memory_limit() failed.")
+
+
+def set_process_memory_limit(mem_in_bytes):
+    """This can be used to limit the available address space / memory to
+    something less than is allocated to the container.   Potentially that
+    will cause Python to generate a MemoryError rather than forcing a
+    container memory limit kill.
+    """
+    resource.setrlimit(resource.RLIMIT_AS, (mem_in_bytes, mem_in_bytes))
+
+
+def test():
+    from caldp import sysexit
+    import doctest
+
+    return doctest.testmod(sysexit)
+
+
+if __name__ == "__main__":
+    print(test())

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -610,10 +610,10 @@ def message_status_check(input_uri, output_uri, ipppssoot):
     assert msg.msg_dir == os.path.join(os.getcwd(), "messages")
     assert msg.stat == 0
 
-    msg.start_message()
+    msg.init()
     assert os.path.exists(msg.msg_dir)
-    assert msg.name == f"submit-{ipppssoot}"
-    assert msg.file == f"{msg.msg_dir}/{msg.name}"
+    # assert msg.name == f"submit-{ipppssoot}"
+    # assert msg.file == f"{msg.msg_dir}/{msg.name}"
     assert msg.stat == 1
 
     msg.process_message()

--- a/scripts/caldp-docker-run-container
+++ b/scripts/caldp-docker-run-container
@@ -1,4 +1,4 @@
-#! /bin/bash -eux
+#! /bin/bash -eu
 
 #
 # Does Docker setup and runs commands in the CALDP container on a
@@ -49,7 +49,9 @@ fi
 # visible inside the container.
 #
 CRDS_SRC=${CRDS_PATH:-/grp/crds/hst}
-if [[ "$CRDS_READONLY_CACHE" == "0" && "$CRDS_SRC" != "/grp/crds/hst" ]]; then
+READONLY=${CRDS_READONLY_CACHE:-0}
+
+if [[ "$READONLY" == "0" && "$CRDS_SRC" != "/grp/crds/hst" ]]; then
     MOUNTS="${MOUNTS} --mount type=bind,source=${CRDS_SRC},target=/grp/crds/cache"
 else
     MOUNTS="${MOUNTS} --mount type=bind,source=${CRDS_SRC},target=/grp/crds/cache,readonly"

--- a/scripts/caldp-ecr-login
+++ b/scripts/caldp-ecr-login
@@ -1,0 +1,14 @@
+#! /bin/bash -e
+
+if [[ $# != 1 ]]; then
+    echo "usage:  $0 <ADMIN_ROLENAME>"
+fi
+
+ADMIN_ROLENAME=$1
+
+ACCOUNT_ID=$(aws sts get-caller-identity | grep Account | cut -d'"' -f4)
+
+ADMIN_ARN="arn:aws:iam::${ACCOUNT_ID}:role/$ADMIN_ROLENAME"
+
+awsudo ${ADMIN_ARN} aws ecr get-login-password --region=us-east-1 | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+

--- a/scripts/caldp-image-build
+++ b/scripts/caldp-image-build
@@ -4,4 +4,6 @@
 
 source caldp-image-config
 
+rm -rf .tox   # this makes a huge Docker build context and is reconstructed automatically
+
 docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=$CAL_BASE_IMAGE  .

--- a/scripts/caldp-image-sh
+++ b/scripts/caldp-image-sh
@@ -1,0 +1,11 @@
+#! /bin/sh -eu
+
+# Debug script that runs a bash shell inside the CALDP container with CRDS
+# configured for offsite use.  Configure Docker for an interactive terminal
+# session which can cause problems for other use cases.
+
+export CALDP_DOCKER_RUN_PARS="--rm -it"
+
+source caldp-config-offsite
+
+caldp-docker-run-container /bin/bash

--- a/scripts/caldp-process
+++ b/scripts/caldp-process
@@ -72,7 +72,6 @@ if [ $output_path != "none" -a $output_location == 's3' ]; then
     fi
 fi
 
-
 echo ........................................ processing log ..............................................
 pwd
 set -o pipefail && $TIME --verbose -o process_metrics.txt \
@@ -83,9 +82,6 @@ echo "Processing exit status ${process_exit_status}"
 
 processing_output_dir=`caldp-get-output-path  $output_path $ipppssoot`
 echo "Processing output_dir is" $processing_output_dir
-
-# logs_output_dir="${processing_output_dir}/logs"
-# echo "Logs output_dir is" $logs_output_dir
 
 previews_output_dir="${processing_output_dir}/previews"
 echo "Previews output_dir is" $previews_output_dir
@@ -111,5 +107,30 @@ echo ........................... handling outputs for ${output_location} .......
 
 # Note: this action is not logged since log files are being transferred.
 python -m caldp.messages $input_path $output_path $ipppssoot
+messages_exit_status=$?
+echo "messages exit status = ${messages_exit_status}"
 
-[[ $process_exit_status -eq 0 && $preview_exit_status -eq 0 ]] || exit 1
+# This is iffy:  only report MemoryError if the program returns non-zero status.  Otherwise assume it dealt with it.
+if [[ $process_exit_status -ne 0 ]]; then
+    grep MemoryError process.txt
+    if [[ $? -eq 0 ]]; then
+        echo "MemoryError found in process.txt;  exiting with status 31,  SUBPROCESS_MEMORY_ERROR"
+        exit 31
+    else
+        echo "Exiting with processing status ${process_exit_status}"
+        exit $process_exit_status
+    fi
+fi
+
+if [[ $preview_exit_status -ne 0 ]]; then
+    echo "Exiting with preview status ${preview_exit_status}"
+    exit $preview_exit_status
+fi
+
+if [[ $messages_exit_status -ne 0 ]]; then
+    echo "Exiting with message status ${messages_exit_status}"
+    exit $preview_exit_status
+fi
+
+echo "Exiting normally, status 0"
+exit 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,36 @@
+[tox]
+envlist = black, flake8, bandit  #, coverage, pytest
+
+[testenv:black]
+basepython = python3.8
+extras = dev
+whitelist_externals = black
+commands=
+    black --check caldp
+
+[testenv:flake8]
+basepython = python3.8
+extras = dev
+whitelist_externals = flake8
+commands =
+    flake8 --count --ignore E501,W503,E203 --max-line-length 88  caldp
+
+[testenv:bandit]
+basepython = python3.8
+extras = dev
+whitelist_externals = bandit
+commands =
+    bandit -ll -r -f txt  caldp
+
+# [testenv:pytest]
+# extras = dev
+# whitelist_externals = pytest
+# commands =
+#     pytest
+
+# [testenv:coverage]
+# basepython = python3.8
+# extras = dev
+# whitelist_externals = pytest
+# commands =
+#     pytest --cov=caldp --cov-fail-under 95


### PR DESCRIPTION
Still working on it,  but so far:

Improvements to error reporting in caldp.process and caldp-process to better
  utilize program exit status, most critically to characterize Astrodrizzle
  memory errors with exit status visible in the batch failure events.
Added exit_codes.py file to be shared-with/copied-to CALCLOUD verbatim.
Added exit handling functions and context managers,  with doctests,  to make
  exit handling code standard and succinct.  sysexit module.
Added caldp-ecr-login <admin_role> script to make it simpler to login to
  the ECR repository.  Personal perk.
Added tox.ini to facilitate command line flake8, black, and bandit tests.
Added exit error simulation via CALDP_SIMULATE_ERROR env var which
  can be defined to values in exit_codes.py to simulate exceptions/exits.
Added default for CRDS_READONLY_CACHE in caldp-docker-run-container
  making it slightly easier to run a bash shell in the container.