### PR TITLE
CALCLOUD-235 Address ECR scan vulnerabilities.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,13 @@ ENV MKL_THREADING_LAYER="GNU"
 
 USER root
 
-# RUN yum update  -y
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
+# Removing kernel-headers seems to remove glibc and all packages which use them
+RUN yum remove -y kernel-devel
 RUN yum install -y curl rsync time
+RUN yum update  -y
 
 # ------------------------------------------------------------------------
 # SSL/TLS cert setup for STScI AWS firewalling


### PR DESCRIPTION
 Modified Dockerfile to do yum updates and remove kernel-devel package as a direct way to address 11/12 "high" criticality ECR scan vulnerabilities as well as all lower level vulnerabilities.   The only remaining "high" was limited to ARM platforms.