### PR TITLE
runastrodriz restricted to single core

### DIFF
--- a/caldp/process.py
+++ b/caldp/process.py
@@ -293,6 +293,7 @@ class InstrumentManager:
         return self.run(exit_codes.STAGE1_ERROR, self.stage1, *args)
 
     def run_stage2(self, *args):
+        args.insert(0, "-n 1") #force single core for astrodrizzle
         return self.run(exit_codes.STAGE2_ERROR, self.stage2, *args)
 
     # .............................................................

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -293,7 +293,6 @@ class InstrumentManager:
         return self.run(exit_codes.STAGE1_ERROR, self.stage1, *args)
 
     def run_stage2(self, *args):
-        args.insert(0, "-n 1")  # force single core for astrodrizzle
         return self.run(exit_codes.STAGE2_ERROR, self.stage2, *args)
 
     # .............................................................
@@ -551,12 +550,14 @@ class InstrumentManager:
         if assoc:
             self.run_stage1(*assoc)
             if self.stage2:
+                assoc.insert(0, "-n 1")  # force single core for astrodrizzle
                 self.run_stage2(*assoc)
             return
         unassoc = self.unassoc_files(files)
         if unassoc:
             self.run_stage1(*unassoc)
             if self.stage2:
+                assoc.insert(0, "-n 1")  # force single core for astrodrizzle
                 self.run_stage2(*unassoc)
             return
 

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -550,14 +550,16 @@ class InstrumentManager:
         if assoc:
             self.run_stage1(*assoc)
             if self.stage2:
-                assoc.insert(0, "-n 1")  # force single core for astrodrizzle
+                assoc.insert(0, "-n")  # force single core for astrodrizzle
+                assoc.insert(1, "1")
                 self.run_stage2(*assoc)
             return
         unassoc = self.unassoc_files(files)
         if unassoc:
             self.run_stage1(*unassoc)
             if self.stage2:
-                assoc.insert(0, "-n 1")  # force single core for astrodrizzle
+                assoc.insert(0, "-n")  # force single core for astrodrizzle
+                assoc.insert(1, "1")
                 self.run_stage2(*unassoc)
             return
 

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -293,7 +293,7 @@ class InstrumentManager:
         return self.run(exit_codes.STAGE1_ERROR, self.stage1, *args)
 
     def run_stage2(self, *args):
-        args.insert(0, "-n 1") #force single core for astrodrizzle
+        args.insert(0, "-n 1")  # force single core for astrodrizzle
         return self.run(exit_codes.STAGE2_ERROR, self.stage2, *args)
 
     # .............................................................

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -546,21 +546,20 @@ class InstrumentManager:
         None
         """
         self.track_versions(files)
+        astrodriz_params = ["-n", "1"]
         assoc = self.assoc_files(files)
         if assoc:
             self.run_stage1(*assoc)
             if self.stage2:
-                assoc.insert(0, "-n")  # force single core for astrodrizzle
-                assoc.insert(1, "1")
-                self.run_stage2(*assoc)
+                args = astrodriz_params + assoc
+                self.run_stage2(*args)
             return
         unassoc = self.unassoc_files(files)
         if unassoc:
             self.run_stage1(*unassoc)
             if self.stage2:
-                assoc.insert(0, "-n")  # force single core for astrodrizzle
-                assoc.insert(1, "1")
-                self.run_stage2(*unassoc)
+                args = astrodriz_params + unassoc
+                self.run_stage2(*args)
             return
 
     def output_files(self):


### PR DESCRIPTION
there is a theory that our infinite job hangs are due to multiprocessing issues when python runs out of memory. This restricts astrodrizzle to a single CPU in the hopes of memory failures relinquishing their threads back to the OS and eventually, Batch.