### PR TITLE
crds bestrefs retries

### DIFF
--- a/caldp/process.py
+++ b/caldp/process.py
@@ -505,7 +505,8 @@ class InstrumentManager:
             self.divider("Computing bestrefs and downloading references.", files)
             bestrefs_files = self.raw_files(files)
             # Only sync reference files if the cache is read/write.
-            bestrefs.assign_bestrefs(
+            retry_bestrefs = sysexit.retry(bestrefs.assign_bestrefs)
+            retry_bestrefs(
                 bestrefs_files,
                 context=os.environ.get("CRDS_CONTEXT", default=None),
                 sync_references=os.environ.get("CRDS_READONLY_CACHE", "0") != "1",

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -756,5 +756,7 @@ def check_sysexit_retry():
 
     retry_no_exc = sysexit.retry(no_exc_func)
     retry_exc = sysexit.retry(exc_func)
+
+    retry_no_exc()
     with pytest.raises(NotImplementedError):
         retry_exc()

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -11,6 +11,7 @@ from caldp import process
 from caldp import create_previews
 from caldp import messages
 from caldp import file_ops
+from caldp import sysexit
 
 
 # ----------------------------------------------------------------------------------------
@@ -418,6 +419,7 @@ def coretst(temp_dir, ipppssoot, input_uri, output_uri):
         check_messages_cleanup(ipppssoot)
         if input_uri.startswith("astroquery"):
             check_IO_clean_up(ipppssoot)
+        check_sysexit_retry()
     finally:
         os.chdir(temp_dir)
 
@@ -743,3 +745,16 @@ def message_status_check(input_uri, output_uri, ipppssoot):
         assert msg.name == f"error-{ipppssoot}"
     elif msg.stat == 3:
         assert msg.name == f"processed-{ipppssoot}.trigger"
+
+
+def check_sysexit_retry():
+    def no_exc_func(arg1=True):
+        pass
+
+    def exc_func(arg1=True):
+        raise NotImplementedError
+
+    retry_no_exc = sysexit.retry(no_exc_func)
+    retry_exc = sysexit.retry(exc_func)
+    with pytest.raises(NotImplementedError):
+        retry_exc()


### PR DESCRIPTION
adds a decorator function to sysexit with a configurable exponential backoff retry. It is safe to use inside a sysexit.exit_on_exception context manager, as it will catch the exception during retrying, and then eventually re-raise it at the end to be caught by the context manager.