### PR TITLE
Explain subprocess signal exit codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,6 @@ COPY scripts/fix-certs .
 
 RUN ./fix-certs
 
-RUN pip install --upgrade pip
-RUN pip install awscli boto3
-# RUN pip install jupyterlab
-RUN pip install spec-plots==1.34.6
-
 # Install s/w dev tools for fitscut build
 RUN yum install -y \
    emacs-nox \
@@ -79,6 +74,13 @@ RUN ./caldp-install-fitscut   /usr/local && \
    echo "/usr/local/lib" >> /etc/ld.so.conf && \
    ldconfig
 
+USER developer
+RUN pip install --upgrade pip
+RUN pip install awscli boto3
+# RUN pip install jupyterlab
+RUN pip install spec-plots==1.34.6
+
+USER root
 # Install caldp pip package from local source
 WORKDIR /home/developer
 RUN mkdir /home/developer/caldp
@@ -88,6 +90,12 @@ RUN chown -R developer.developer /home/developer
 # CRDS cache mount point or container storage.
 RUN mkdir -p /grp/crds/cache && chown -R developer.developer /grp/crds/cache
 
+# Part #2 of turning on core dumps
+# # These are also Terraformed as Docker --ulimit,  container runtime also needs to permit.
+# RUN echo "*               soft    core            -1" >> /etc/security/limits.conf &&\
+#     echo "*               hard    core            -1" >> /etc/security/limits.conf
+
+# ------------------------------------------------
 USER developer
+
 RUN cd caldp  &&  pip install .[dev,test]
-RUN cd /opt/conda/lib/python3.6/site-packages/photutils && patch -p 0 -F 3 __init__.py /home/developer/caldp/ascii_fix.patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,13 +74,6 @@ RUN ./caldp-install-fitscut   /usr/local && \
    echo "/usr/local/lib" >> /etc/ld.so.conf && \
    ldconfig
 
-USER developer
-RUN pip install --upgrade pip
-RUN pip install awscli boto3
-# RUN pip install jupyterlab
-RUN pip install spec-plots==1.34.6
-
-USER root
 # Install caldp pip package from local source
 WORKDIR /home/developer
 RUN mkdir /home/developer/caldp

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -287,7 +287,7 @@ class InstrumentManager:
             if err in self.ignore_err_nums:
                 log.info("Ignoring error status =", err)
             elif err:
-                raise RuntimeError(f"Subprocess returned with non-zero status = {err}")
+                raise sysexit.SubprocessFailure(err)
 
     def run_stage1(self, *args):
         return self.run(exit_codes.STAGE1_ERROR, self.stage1, *args)

--- a/caldp/sysexit.py
+++ b/caldp/sysexit.py
@@ -137,7 +137,7 @@ def exit_on_exception(exit_code, *args):
     ERROR - ----------------------------- Fatal Exception -----------------------------
     ERROR - Failure running processing stage1.
     ERROR - Traceback (most recent call last):
-    ERROR -   File "/home/ec2-user/jmiller/caldp/caldp/sysexit.py", line ..., in exit_on_exception
+    ERROR -   File ".../caldp/sysexit.py", line ..., in exit_on_exception
     ERROR -     yield
     ERROR -   File "<doctest caldp.sysexit.exit_on_exception[...]>", line ..., in <module>
     ERROR -     raise SubprocessFailure(-8)

--- a/caldp/sysexit.py
+++ b/caldp/sysexit.py
@@ -42,6 +42,24 @@ class CaldpExit(SystemExit):
     """Handle like SystemExit,  but we definitely threw it."""
 
 
+class SubprocessFailure(Exception):
+    """A called subprocess failed and may require signal reporting.
+
+    In Python, a negative subprocess returncode indicates that the absolete
+    value of the returncode is a signal number which killed the subprocess.
+
+    For completeness, in Linux, the program exit_code is a byte value.  If the
+    sign bit is set, a signal and/or core dump occurred.  The byte reported as
+    exit_code may be unsigned.  The lower bits of the returncode define either
+    the program's exit status or a signum identifying the signal which killed
+    the process.
+
+    """
+
+    def __init__(self, returncode):
+        self.returncode = returncode
+
+
 @contextlib.contextmanager
 def exit_on_exception(exit_code, *args):
     """exit_on_exception is a context manager which issues an error message
@@ -58,7 +76,7 @@ def exit_on_exception(exit_code, *args):
     ...        print("do it.")
     ... except SystemExit:
     ...    log.divider()
-    ...    print("Trapping SystemExit normally caught by log.exit_reciever() at top level.")
+    ...    print("Trapping SystemExit normally caught by exit_reciever() at top level.")
     ERROR - ----------------------------- Fatal Exception -----------------------------
     ERROR - As expected it failed.
     ERROR - Traceback (most recent call last):
@@ -69,7 +87,7 @@ def exit_on_exception(exit_code, *args):
     ERROR - Exception: It failed!
     EXIT - CMDLINE_ERROR[2]: The program command line invocation was incorrect.
     INFO - ---------------------------------------------------------------------------
-    Trapping SystemExit normally caught by log.exit_reciever() at top level.
+    Trapping SystemExit normally caught by exit_reciever() at top level.
 
     Never printed 'do it.'  SystemExit is caught for testing.
 
@@ -111,6 +129,21 @@ def exit_on_exception(exit_code, *args):
     should print normally
 
     >>> del os.environ["CALDP_SIMULATE_ERROR"]
+
+    >>> with exit_receiver():  #doctest: +ELLIPSIS
+    ...     with exit_on_exception(exit_codes.STAGE1_ERROR, "Failure running processing stage1."):
+    ...         raise SubprocessFailure(-8)
+    ERROR - ----------------------------- Fatal Exception -----------------------------
+    ERROR - Failure running processing stage1.
+    ERROR - Traceback (most recent call last):
+    ERROR -   File "/home/ec2-user/jmiller/caldp/caldp/sysexit.py", line ..., in exit_on_exception
+    ERROR -     yield
+    ERROR -   File "<doctest caldp.sysexit.exit_on_exception[...]>", line ..., in <module>
+    ERROR -     raise SubprocessFailure(-8)
+    ERROR - caldp.sysexit.SubprocessFailure: -8
+    EXIT - Killed by UNIX signal SIGFPE[8]: 'Floating-point exception (ANSI).'
+    EXIT - STAGE1_ERROR[23]: An error occurred in this instrument's stage1 processing step. e.g. calxxx
+    os._exit(23)
     """
     simulated_code = int(os.environ.get("CALDP_SIMULATE_ERROR", "0"))
     try:
@@ -131,12 +164,18 @@ def exit_on_exception(exit_code, *args):
         raise CaldpExit(exit_codes.CALDP_MEMORY_ERROR)
     except CaldpExit:
         raise
+    # below as always exit_code defines what will be CALDP's program exit status.
+    # in contrast,  exc.returncode is the subprocess exit status of a failed subprocess which may
+    # define an OS signal that killed the process.
+    except SubprocessFailure as exc:
+        _report_exception(exit_code, args, exc.returncode)
+        raise CaldpExit(exit_code)
     except Exception:
         _report_exception(exit_code, args)
         raise CaldpExit(exit_code)
 
 
-def _report_exception(exit_code, args=None):
+def _report_exception(exit_code, args=None, returncode=None):
     """Issue trigger output for exit_on_exception, including `exit_code` and
     error message defined by `args`, as well as traceback.
     """
@@ -146,6 +185,8 @@ def _report_exception(exit_code, args=None):
     for line in traceback.format_exc().splitlines():
         if line != "NoneType: None":
             log.error(line)
+    if returncode and returncode < 0:
+        print(exit_codes.explain_signal(-returncode))
     print(exit_codes.explain(exit_code))
 
 

--- a/caldp/sysexit.py
+++ b/caldp/sysexit.py
@@ -130,6 +130,7 @@ def exit_on_exception(exit_code, *args):
 
     >>> del os.environ["CALDP_SIMULATE_ERROR"]
 
+    >>> saved, os._exit = os._exit, lambda x: print(f"os._exit({x})")
     >>> with exit_receiver():  #doctest: +ELLIPSIS
     ...     with exit_on_exception(exit_codes.STAGE1_ERROR, "Failure running processing stage1."):
     ...         raise SubprocessFailure(-8)
@@ -144,6 +145,7 @@ def exit_on_exception(exit_code, *args):
     EXIT - Killed by UNIX signal SIGFPE[8]: 'Floating-point exception (ANSI).'
     EXIT - STAGE1_ERROR[23]: An error occurred in this instrument's stage1 processing step. e.g. calxxx
     os._exit(23)
+    >>> os._exit = saved
     """
     simulated_code = int(os.environ.get("CALDP_SIMULATE_ERROR", "0"))
     try:

--- a/scripts/caldp-process
+++ b/scripts/caldp-process
@@ -58,7 +58,12 @@ echo ........................................ Environment ......................
 echo "User is" `whoami`
 echo "Current dir is" `pwd`
 printenv | sort
+
+echo ........................................ Directory Perms  ..............................................
 ls -ld .
+
+echo ........................................ Ulimits ..............................................
+ulimit -a
 
 output_location=`echo $output_path | cut -d':' -f1`
 


### PR DESCRIPTION
Added explanation of negative subprocess return codes which correspond to UNIX
  signals which kill processes.  Reporting the signal status associated with a
  killed process is roughly equivalent to getting the status reported in the
  aftermath of a core dump.
Re-order Dockerfile and use developer user for pip installs to avoid pip complaints
  and improve typical build times.
Add "ulimit -a" dump to caldp-process to get the container's perception of various
  process limits,  including core dump configuration;  this may be fictional and/or
  require additional configuration in Terraform to set the docker run --ulimit
  parameter.