### PR TITLE
actions to tag on push and merge main to develop

### DIFF
--- a/.github/scripts/merge-main-to-develop.sh
+++ b/.github/scripts/merge-main-to-develop.sh
@@ -1,0 +1,8 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git fetch
+git checkout develop
+git merge -m "github action merged main into develop" main --verbose
+git push

--- a/.github/scripts/tag-latest.sh
+++ b/.github/scripts/tag-latest.sh
@@ -1,0 +1,9 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git checkout develop
+rev=`git rev-parse --short develop`
+git tag -f "latest" -m "latest tag updated to rev ${rev} on develop"
+git push origin :latest
+git push origin latest

--- a/.github/scripts/tag-stable.sh
+++ b/.github/scripts/tag-stable.sh
@@ -1,0 +1,9 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git checkout main
+rev=`git rev-parse --short main`
+git tag -f "stable" -m "stable tag updated to rev ${rev} on main"
+git push origin :stable
+git push origin stable

--- a/.github/workflows/merge-main-to-develop.yml
+++ b/.github/workflows/merge-main-to-develop.yml
@@ -1,0 +1,23 @@
+name: merge-main-to-develop
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-main-to-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/merge-main-to-develop.sh
+  tag-latest:
+    runs-on: ubuntu-latest
+    needs: merge-main-to-develop
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/tag-latest.sh
+      

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -1,0 +1,12 @@
+name: tag-latest
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  update-latest-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/tag-latest.sh

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -1,0 +1,12 @@
+name: tag-stable
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-stable-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/tag-stable.sh


### PR DESCRIPTION
* adds a GA to tag stable on any push to main
* adds GA to merge main back into develop on any push to main
* adds GA to tag latest on any push to dev
    - note: this doesn't work if the push was done in another GA, hence the merge GA has an extra step to run this script as well

The intended workflow for developers here is that any push to main came either from a hotfix, or a release candidate branch. Any changes there need merged back to develop and this should remove the chance of that getting overlooked during a release. I do have some concerns about that merge failing, and how exactly to handle that.

This is all in the context of me needing to write procedures for other people to be able to create releases. So there will be instructions somewhere on exactly what the procedure is. This auto-merge of main back to dev should help to reduce some steps in that procedure.

As of now, this does not work with branch protection rules that explicitly require PRs, because we're not using any secrets in the repo that would allow the github action user to assume the appropriate privilege level.
