### PR TITLE
PR merge conflict check workflow

### DIFF
--- a/.github/scripts/check-merge-main2develop.sh
+++ b/.github/scripts/check-merge-main2develop.sh
@@ -1,0 +1,7 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git fetch
+git checkout develop
+git merge origin/main --verbose

--- a/.github/workflows/PR-check-merge.yml
+++ b/.github/workflows/PR-check-merge.yml
@@ -1,0 +1,15 @@
+name: check-merge-main2develop
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-merge-main2develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/check-merge-main2develop.sh
+      


### PR DESCRIPTION
* adds workflow to check for merge conflicts with develop, when a PR is opened against main
* this is intended for informational purposes only, because after the PR is merged, another workflow will attempt to auto-merge main back into develop. If this check fails, then that will fail too. At that point developer intervention is required to fix the merge conflicts from main back to develop.
* note that you do not need to fix the conflicts before merging to main. _**informational purposes only**_