### PR TITLE
MNT: Update codecov-action version to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,4 @@ jobs:
           pytest caldp --cov=caldp --cov-fail-under 70 --capture=tee-sys
 
       - name: compute test coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
You are using a deprecated version of `codecov-action`, see https://github.com/codecov/codecov-action for more details. xref astropy/astropy#12245

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.