### PR TITLE
Refactored sysexit exception handling

### DIFF
--- a/caldp/create_previews.py
+++ b/caldp/create_previews.py
@@ -1,7 +1,8 @@
-# This module creates preview images from reprocessing output data.
+"""This module creates preview images from reprocessing output data."""
 
 import argparse
 import os
+import sys
 import subprocess
 import logging
 import glob
@@ -14,6 +15,7 @@ from caldp import process
 from caldp import file_ops
 from caldp import messages
 from caldp import sysexit
+from caldp import exit_codes
 
 # -------------------------------------------------------------------------------------------------------
 
@@ -238,5 +240,6 @@ def cmdline():
 
 
 if __name__ == "__main__":
-    with sysexit.exit_receiver():
+    with sysexit.exit_on_exception():
         cmdline()
+    sys.exit(exit_codes.SUCCESS)

--- a/caldp/process.py
+++ b/caldp/process.py
@@ -851,5 +851,6 @@ if __name__ == "__main__":
     if len(sys.argv) < 4:
         print("usage:  process.py <input_uri>  <output_uri>  <ipppssoot's...>")
         sys.exit(exit_codes.CMDLINE_ERROR)
-    with sysexit.exit_receiver():
+    with sysexit.exit_on_exception():
         main(sys.argv)
+    sys.exit(exit_codes.SUCCESS)


### PR DESCRIPTION
Refactored sysexit exception handling restoring normal usage of sys.exit() and
any implicit Python env cleanup which occurs as a result.  Simplified
README.rst and documentation on sysexit exception handling.

DO NOT MERGE W/O ADDITIONAL REPRO TESTING,  BOTH NOMINAL AND EXCEPTIONS.