### PR TITLE
Release/v0.2.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate caldp_${{ matrix.HSTCAL }}
-          export CRDS_CONTEXT=hst_1013.pmap
+          export CRDS_CONTEXT=hst_1015.pmap
           pytest caldp --cov=caldp --cov-fail-under 70 --capture=tee-sys
 
       - name: compute test coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate caldp_${{ matrix.HSTCAL }}
-          export CRDS_CONTEXT=hst_1002.pmap
+          export CRDS_CONTEXT=hst_1013.pmap
           pytest caldp --cov=caldp --cov-fail-under 70 --capture=tee-sys
 
       - name: compute test coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN yum remove -y kernel-devel   &&\
    patch \
    curl \
    rsync \
-   time
+   time \
+   which
 
 RUN mkdir -p /etc/ssl/certs && \
     mkdir -p /etc/pki/ca-trust/extracted/pem
@@ -89,4 +90,14 @@ RUN mkdir -p /grp/crds/cache && chown -R developer.developer /grp/crds/cache
 
 # ------------------------------------------------
 USER developer
-RUN cd caldp  &&  pip install .[dev,test]
+# for any base docker image created later than and including stsci/hst-pipeline:CALDP_20220420_CAL_final, 
+# the critical base environment is now buried in a conda environment named "linux"
+# this creates various issues with the docker run command
+# I played around for several hours with ways to bury the conda activation in a .bashrc or .bash_profile,
+# but I couldn't get docker to use it when the image was invoked with the docker run command.
+# in the end, the least-risky way to fix the issue seems to be to hardcode the conda activation into the path
+# and bake it straight into the image.
+# --bhayden, 5-24-22
+ENV PATH=/opt/conda/envs/linux/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN cd caldp  && \ 
+    pip install .[dev,test]

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -19,7 +19,7 @@ from caldp import sysexit
 # Set default CRDS Context
 CRDS_CONTEXT = os.environ.get("CRDS_CONTEXT")
 if CRDS_CONTEXT == "":
-    os.environ["CRDS_CONTEXT"] = "hst_1013.pmap"
+    os.environ["CRDS_CONTEXT"] = "hst_1015.pmap"
 
 # For applicable tests,  the product files associated with each ipppssoot below
 # must be present in the CWD after processing and be within 10% of the listed sizes.

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -19,7 +19,7 @@ from caldp import sysexit
 # Set default CRDS Context
 CRDS_CONTEXT = os.environ.get("CRDS_CONTEXT")
 if CRDS_CONTEXT == "":
-    os.environ["CRDS_CONTEXT"] = "hst_1002.pmap"
+    os.environ["CRDS_CONTEXT"] = "hst_1013.pmap"
 
 # For applicable tests,  the product files associated with each ipppssoot below
 # must be present in the CWD after processing and be within 10% of the listed sizes.

--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,2 @@
-- default base docker image set to CALDP_20220406_CAL_final
-- default crds update to hst_1002.pmap
+- default base docker image set to CALDP_20220527_CAL_final
+- default crds update to hst_1015.pmap

--- a/scripts/caldp-image-config
+++ b/scripts/caldp-image-config
@@ -16,5 +16,5 @@ export CALDP_IMAGE_TAG=latest
 export CALDP_DOCKER_IMAGE=${CALDP_IMAGE_REPO}:${CALDP_IMAGE_TAG}
 
 # Fundamental calibration s/w image CALDP image inherits from
-export BASE_IMAGE_TAG=CALDP_20220406_CAL_final
+export BASE_IMAGE_TAG=CALDP_cosandhap_CAL_rc3
 export CAL_BASE_IMAGE=stsci/hst-pipeline:${BASE_IMAGE_TAG}

--- a/scripts/caldp-image-config
+++ b/scripts/caldp-image-config
@@ -16,5 +16,5 @@ export CALDP_IMAGE_TAG=latest
 export CALDP_DOCKER_IMAGE=${CALDP_IMAGE_REPO}:${CALDP_IMAGE_TAG}
 
 # Fundamental calibration s/w image CALDP image inherits from
-export BASE_IMAGE_TAG=CALDP_cosandhap_CAL_rc3
+export BASE_IMAGE_TAG=CALDP_20220527_CAL_final
 export CAL_BASE_IMAGE=stsci/hst-pipeline:${BASE_IMAGE_TAG}

--- a/scripts/caldp-install-fitscut
+++ b/scripts/caldp-install-fitscut
@@ -12,9 +12,9 @@ cd install-fitscut.tmp/
 git clone https://github.com/healpy/cfitsio.git
 cd cfitsio && git checkout 8838182 && ./configure --prefix=${PREFIX} && make && make install
 
-wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.5.tar.gz
-tar -zxf wcstools-3.9.5.tar.gz
-cd wcstools-3.9.5 && make
+wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.7.tar.gz
+tar -zxf wcstools-3.9.7.tar.gz
+cd wcstools-3.9.7 && make
 mkdir -p ${PREFIX}/include/libwcs
 cp libwcs/*.h ${PREFIX}/include/libwcs
 cp libwcs/*.a ${PREFIX}/lib


### PR DESCRIPTION
- default base docker image set to CALDP_20220527_CAL_final
- default crds update to hst_1015.pmap
- bugfix for processing env in base image using new conda env
- update wcstools to 3.9.7 as the 3.9.5 download link is no longer available