### PR TITLE
Fixed CALDP process log utf-8 decode

### DIFF
--- a/caldp/process.py
+++ b/caldp/process.py
@@ -372,7 +372,7 @@ class Manager:
         with sysexit.exit_on_exception(exit_code, self.dataset, "Command:", repr(cmd)):
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             for line in p.stdout:
-                log.echo(line.strip().decode("utf-8"))
+                log.echo(line.strip().decode("utf-8", "backslashreplace"))
             if p.returncode in self.ignore_err_nums:
                 log.info("Ignoring error status =", p.returncode)
             elif p.returncode:


### PR DESCRIPTION
Added backslashreplace option to caldp subprocess log utf-8 decoding to handle program log character sequences which are not utf-8 w/o crashing.  This is to address invalid characters for utf-8 emitted by calacs.e which are at least vaguely related to the ACS SPOTTAB reference file 61i17241j_csp.fits which was replaced due to the same issue which at the time crashed the DMS downstream of CALDP.  Note that ultimately we believe there is a bug in calacs.e which is causing bad log output; still this change is needed to tolerate such output if it is benign and should help with debug if it is not.