### PR TITLE
stsci/hst-pipeline image is upgrading from centos:7 to centos:stream9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ USER root
 
 # Removing kernel-headers seems to remove glibc and all packages which use them
 # Install s/w dev tools for fitscut build
-RUN yum remove -y kernel-devel   &&\
+RUN yum remove -y kernel-devel && \
+ yum install -y epel-release && \
  yum update  -y && \
  yum install -y \
    emacs-nox \


### PR DESCRIPTION
Now that CentOS 7 is fully end-of-life and the mirrors have been turned off I'm in the process of upgrading `stsci/hst-pipeline` from `centos:7` to `quay.io/centos/centos:stream9`.

Red Hat moved the `htop` package (a dependency listed in your Dockerfile) out of the base repository and into EPEL. This PR enables EPEL to prevent build errors after the upstream image is pushed to dockerhub.

On grit, the following was merged into `spb-infrastructure/deliver_hcaldp`

```diff
commit f5002b8a15a1277fb92669f638a364d4655124bd (HEAD -> stream9-upgrade, origin/stream9-upgrade)
Author: ---- <----@---->
Date:   Wed Jul 17 12:51:25 2024 -0400

    Upgrade to CentOS Stream9

diff --git a/Dockerfile b/Dockerfile
index e17af58..33d096e 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream9
 
 # Declare build-time environment
 
 # Miniconda
-ARG MC_VERSION=23.11.0-0
+ARG MC_VERSION=24.3.0-0
 ARG MC_PLATFORM=Linux
 ARG MC_ARCH=x86_64
 ARG MC_INSTALLER=Miniforge3-${MC_VERSION}-${MC_PLATFORM}-${MC_ARCH}.sh
@@ -34,9 +34,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Toolchain
 RUN yum update -y \
+    && yum install -y --allowerasing curl \ 
     && yum install -y \
         bzip2-devel \
-        curl \
         gcc \
         gcc-c++ \
         gcc-gfortran \
```

New RC and FINAL deliveries coming out of SCSB will be based on `centos:stream9`. Old/existing images on dockerhub have not been modified.