### PR TITLE
Release/v0.2.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ USER root
 
 # Removing kernel-headers seems to remove glibc and all packages which use them
 # Install s/w dev tools for fitscut build
-RUN yum install -y epel-release && \
- yum remove -y kernel-devel && \
+RUN  yum remove -y kernel-devel && \
+ yum install -y epel-release && \
  yum update  -y && \
  yum install -y \
    emacs-nox \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,24 @@ ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 USER root
 
+RUN mkdir -p /etc/ssl/certs && \
+    mkdir -p /etc/pki/ca-trust/extracted/pem && \
+    mkdir -p /etc/pki/ca-trust/source/anchors
+#COPY tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+COPY STSCICA.crt /etc/ssl/certs/STSCICA.crt
+COPY STSCICA.crt /etc/pki/ca-trust/source/anchors/STSCICA.crt
+RUN update-ca-trust
+RUN mv /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt.org && \
+    ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem  /etc/ssl/certs/ca-bundle.crt && \
+   #  mv /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt.org && \
+    ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt && \
+   #  ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /usr/lib/ssl/cert.pem && \
+    mkdir -p /etc/pki/ca-trust/extracted/openssl
+
+# RUN npm config set cafile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+COPY scripts/fix-certs .
+RUN ./fix-certs
+
 # Removing kernel-headers seems to remove glibc and all packages which use them
 # Install s/w dev tools for fitscut build
 RUN  yum remove -y kernel-devel && \
@@ -47,24 +65,6 @@ RUN  yum remove -y kernel-devel && \
    rsync \
    time \
    which
-
-RUN mkdir -p /etc/ssl/certs && \
-    mkdir -p /etc/pki/ca-trust/extracted/pem && \
-    mkdir -p /etc/pki/ca-trust/source/anchors
-#COPY tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-COPY STSCICA.crt /etc/ssl/certs/STSCICA.crt
-COPY STSCICA.crt /etc/pki/ca-trust/source/anchors/STSCICA.crt
-RUN update-ca-trust
-RUN mv /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt.org && \
-    ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem  /etc/ssl/certs/ca-bundle.crt && \
-   #  mv /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt.org && \
-    ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt && \
-   #  ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /usr/lib/ssl/cert.pem && \
-    mkdir -p /etc/pki/ca-trust/extracted/openssl
-
-# RUN npm config set cafile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-COPY scripts/fix-certs .
-RUN ./fix-certs
 
 # Install fitscut
 COPY scripts/caldp-install-fitscut  .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ USER root
 
 # Removing kernel-headers seems to remove glibc and all packages which use them
 # Install s/w dev tools for fitscut build
-RUN yum remove -y kernel-devel   &&\
- yum install -y epel-release && \
+RUN yum install -y epel-release && \
+ yum remove -y kernel-devel && \
  yum update  -y && \
  yum install -y \
    emacs-nox \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ USER root
 # Removing kernel-headers seems to remove glibc and all packages which use them
 # Install s/w dev tools for fitscut build
 RUN yum remove -y kernel-devel   &&\
+ yum install -y epel-release && \
  yum update  -y && \
  yum install -y \
    emacs-nox \
@@ -94,7 +95,7 @@ RUN mkdir -p /grp/crds/cache && chown -R developer.developer /grp/crds/cache
 
 # ------------------------------------------------
 USER developer
-# for any base docker image created later than and including stsci/hst-pipeline:CALDP_20220420_CAL_final, 
+# for any base docker image created later than and including stsci/hst-pipeline:CALDP_20220420_CAL_final,
 # the critical base environment is now buried in a conda environment named "linux"
 # this creates various issues with the docker run command
 # I played around for several hours with ways to bury the conda activation in a .bashrc or .bash_profile,
@@ -103,5 +104,5 @@ USER developer
 # and bake it straight into the image.
 # --bhayden, 5-24-22
 ENV PATH=/opt/conda/envs/linux/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN cd caldp  && \ 
+RUN cd caldp  && \
     pip install .[dev,test]

--- a/caldp-setup
+++ b/caldp-setup
@@ -6,10 +6,10 @@ export PATH=`pwd`/scripts:${PATH}
 # Define the exact version of reference files you want to use.
 # Specify "hst-operational" if you want it defined automatically
 # by the CRDS server and/or cache.
-export CRDS_CONTEXT=hst_1168.pmap
+export CRDS_CONTEXT=hst_1169.pmap
 
 # Version of stsci/hst-pipeline base image to use
-export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc2
+export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc4
 
 # Docker repo
 #

--- a/caldp-setup
+++ b/caldp-setup
@@ -9,7 +9,7 @@ export PATH=`pwd`/scripts:${PATH}
 export CRDS_CONTEXT=hst_1169.pmap
 
 # Version of stsci/hst-pipeline base image to use
-export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc5
+export BASE_IMAGE_TAG=CALDP_20240813_CAL_final
 
 # Docker repo
 #

--- a/caldp-setup
+++ b/caldp-setup
@@ -6,10 +6,10 @@ export PATH=`pwd`/scripts:${PATH}
 # Define the exact version of reference files you want to use.
 # Specify "hst-operational" if you want it defined automatically
 # by the CRDS server and/or cache.
-export CRDS_CONTEXT=hst_1155.pmap
+export CRDS_CONTEXT=hst_1168.pmap
 
 # Version of stsci/hst-pipeline base image to use
-export BASE_IMAGE_TAG=CALDP_20240509_CAL_final
+export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc2
 
 # Docker repo
 #

--- a/caldp-setup
+++ b/caldp-setup
@@ -9,7 +9,7 @@ export PATH=`pwd`/scripts:${PATH}
 export CRDS_CONTEXT=hst_1169.pmap
 
 # Version of stsci/hst-pipeline base image to use
-export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc4
+export BASE_IMAGE_TAG=CALDP_mostlyCOS_CAL_rc5
 
 # Docker repo
 #

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -364,7 +364,7 @@ HAP_RESULTS = dict(
 168327360 inputs/j8ph01g9q_flc.fits
 3617827 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g3_drc.jpg
 4481418 inputs/hst_9774_01_acs_wfc_f814w_j8ph01_drc.jpg
-632332 inputs/hst_9774_01_acs_wfc_f814w_j8ph01_segment-cat.ecsv
+1922326 inputs/hst_9774_01_acs_wfc_f814w_j8ph01_segment-cat.ecsv
 4099 inputs/hst_9774_01_acs_wfc_f555w_j8ph01_drc_thumb.jpg
 336142080 inputs/hst_9774_01_acs_wfc_f814w_j8ph01g0_drc.fits
 336142080 inputs/hst_9774_01_acs_wfc_f814w_j8ph01g1_drc.fits
@@ -415,7 +415,7 @@ HAP_RESULTS = dict(
 146132 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01_point-cat.ecsv
 112320 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01g7_hlet.fits
 7659 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01g9_trl.txt
-632332 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01_segment-cat.ecsv
+1922326 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01_segment-cat.ecsv
 336142080 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01g0_drc.fits
 336142080 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01g1_drc.fits
 21020 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_trl.txt

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -371,7 +371,7 @@ HAP_RESULTS = dict(
 21020 inputs/hst_9774_01_acs_wfc_f435w_j8ph01_trl.txt
 2864520 inputs/hst_9774_01_acs_wfc_f555w_j8ph01g9_drc.jpg
 336142080 inputs/hst_9774_01_acs_wfc_f555w_j8ph01g7_drc.fits
-634886 inputs/hst_9774_01_acs_wfc_f435w_j8ph01_segment-cat.ecsv
+1928070 inputs/hst_9774_01_acs_wfc_f435w_j8ph01_segment-cat.ecsv
 7659 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g3_trl.txt
 20150 inputs/hst_9774_01_acs_wfc_f814w_j8ph01_trl.txt
 168327360 inputs/j8ph01g5q_flc.fits
@@ -420,7 +420,7 @@ HAP_RESULTS = dict(
 336142080 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01g1_drc.fits
 21020 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_trl.txt
 336142080 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01g7_drc.fits
-634886 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_segment-cat.ecsv
+1928070 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_segment-cat.ecsv
 7659 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01g3_trl.txt
 20150 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01_trl.txt
 214045 outputs/acs_8ph_01/hst_9774_01_acs_wfc_total_j8ph01_segment-cat.ecsv

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -322,7 +322,7 @@ HAP_RESULTS = dict(
 7685 inputs/hst_9774_01_acs_wfc_f555w_j8ph01g7_trl.txt
 336142080 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g3_drc.fits
 5453 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g5_drc_thumb.jpg
-634177 inputs/hst_9774_01_acs_wfc_f555w_j8ph01_segment-cat.ecsv
+1930179 inputs/hst_9774_01_acs_wfc_f555w_j8ph01_segment-cat.ecsv
 32787 inputs/hst_9774_01_acs_wfc_j8p_metawcs_all_ref_cat.ecsv
 7690 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g5_trl.txt
 21024 inputs/hst_9774_01_acs_wfc_f555w_j8ph01_trl.txt
@@ -391,7 +391,7 @@ HAP_RESULTS = dict(
 5476 inputs/hst_9774_01_acs_wfc_f555w_j8ph01g7_drc_thumb.jpg
 7685 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01g7_trl.txt
 336142080 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01g3_drc.fits
-634177 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01_segment-cat.ecsv
+1930179 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01_segment-cat.ecsv
 7690 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01g5_trl.txt
 21024 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01_trl.txt
 336150720 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01_drc.fits

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -20,7 +20,7 @@ from moto import mock_aws
 # Set default CRDS Context
 CRDS_CONTEXT = os.environ.get("CRDS_CONTEXT")
 if CRDS_CONTEXT == "":
-    os.environ["CRDS_CONTEXT"] = "hst_1168.pmap"
+    os.environ["CRDS_CONTEXT"] = "hst_1169.pmap"
 
 # For applicable tests,  the product files associated with each ipppssoot below
 # must be present in the CWD after processing and be within 10% of the listed sizes.

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -20,7 +20,7 @@ from moto import mock_aws
 # Set default CRDS Context
 CRDS_CONTEXT = os.environ.get("CRDS_CONTEXT")
 if CRDS_CONTEXT == "":
-    os.environ["CRDS_CONTEXT"] = "hst_1155.pmap"
+    os.environ["CRDS_CONTEXT"] = "hst_1168.pmap"
 
 # For applicable tests,  the product files associated with each ipppssoot below
 # must be present in the CWD after processing and be within 10% of the listed sizes.

--- a/caldp/tests/test_all.py
+++ b/caldp/tests/test_all.py
@@ -375,7 +375,7 @@ HAP_RESULTS = dict(
 7659 inputs/hst_9774_01_acs_wfc_f435w_j8ph01g3_trl.txt
 20150 inputs/hst_9774_01_acs_wfc_f814w_j8ph01_trl.txt
 168327360 inputs/j8ph01g5q_flc.fits
-214045 inputs/hst_9774_01_acs_wfc_total_j8ph01_segment-cat.ecsv
+614712 inputs/hst_9774_01_acs_wfc_total_j8ph01_segment-cat.ecsv
 336150720 inputs/hst_9774_01_acs_wfc_f435w_j8ph01_drc.fits
 1780 inputs/acs_8ph_01_manifest.txt
 5945138 inputs/hst_9774_01_acs_wfc_total_j8ph01_drc_color.jpg
@@ -423,7 +423,7 @@ HAP_RESULTS = dict(
 1928070 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_segment-cat.ecsv
 7659 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01g3_trl.txt
 20150 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f814w_j8ph01_trl.txt
-214045 outputs/acs_8ph_01/hst_9774_01_acs_wfc_total_j8ph01_segment-cat.ecsv
+614712 outputs/acs_8ph_01/hst_9774_01_acs_wfc_total_j8ph01_segment-cat.ecsv
 336150720 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f435w_j8ph01_drc.fits
 1780 outputs/acs_8ph_01/acs_8ph_01_manifest.txt
 168448320 outputs/acs_8ph_01/hst_9774_01_acs_wfc_f555w_j8ph01g7_flc.fits

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,3 @@
-- default base docker image set to CALDP_infrastructure_CAL_rc3
-- default crds update to hst_1155.pmap
-- black and mock_s3 fixes
-- fix chdir in make_color_preview
+- default base docker image set to CALDP_mostlyCOS_CAL_rc2
+- default crds update to hst_1168.pmap
+- update to spec-plots 1.36.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,3 @@
-- default base docker image set to CALDP_mostlyCOS_CAL_rc2
-- default crds update to hst_1168.pmap
+- default base docker image set to CALDP_mostlyCOS_CAL_rc4
+- default crds update to hst_1169.pmap
 - update to spec-plots 1.36.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
-- default base docker image set to CALDP_mostlyCOS_CAL_rc4
+- default base docker image set to CALDP_mostlyCOS_CAL_rc5
 - default crds update to hst_1169.pmap
 - update to spec-plots 1.36.0
+- fix Dockerfile after switch to stream9 base image

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     drizzlepac
     boto3
     awscli
-    spec-plots==1.35.1
+    spec-plots==1.36.0
     psutil
 
 [options.extras_require]


### PR DESCRIPTION
- default base docker image set to CALDP_mostlyCOS_CAL_rc5
- default crds update to hst_1169.pmap
- update to spec-plots 1.36.0
- fix Dockerfile after switch to stream9 base image
